### PR TITLE
feat: add Skeleton component

### DIFF
--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -174,7 +174,7 @@
 /* ============================================================
    Skeleton Animation
    ============================================================ */
-@keyframes skeleton-wave {
+@keyframes wave {
   0% {
     background-position: 200% 0;
   }
@@ -184,19 +184,16 @@
 }
 
 @layer utilities {
-  .animate-wave {
-    background-image: linear-gradient(
-      90deg,
-      var(--color-skeleton) 20%,
-      var(--color-skeleton-shimmer) 50%,
-      var(--color-skeleton) 80%
-    );
-    background-size: 200% 100%;
-  }
-
   @media (prefers-reduced-motion: no-preference) {
     .animate-wave {
-      animation: skeleton-wave 1.5s ease-in-out infinite;
+      background-image: linear-gradient(
+        90deg,
+        var(--color-skeleton) 20%,
+        var(--color-skeleton-shimmer) 50%,
+        var(--color-skeleton) 80%
+      );
+      background-size: 200% 100%;
+      animation: wave 1.5s ease-in-out infinite;
     }
   }
 }

--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -88,7 +88,7 @@
 
   /* Colors -- Skeleton */
   --color-skeleton: #d9d9d9;
-  /* --color-skeleton-shimmer: #f0f0f0; */
+  --color-skeleton-shimmer: #ededed;
 
   /* Font Sizes */
   --text-xs: 0.75rem;
@@ -168,5 +168,35 @@
   }
   h6 {
     font-size: var(--text-lg);
+  }
+}
+
+/* ============================================================
+   Skeleton Animation
+   ============================================================ */
+@keyframes skeleton-wave {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@layer utilities {
+  .animate-wave {
+    background-image: linear-gradient(
+      90deg,
+      var(--color-skeleton) 20%,
+      var(--color-skeleton-shimmer) 50%,
+      var(--color-skeleton) 80%
+    );
+    background-size: 200% 100%;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .animate-wave {
+      animation: skeleton-wave 1.5s ease-in-out infinite;
+    }
   }
 }

--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -5,7 +5,8 @@
    ============================================================ */
 @theme {
   /* Font Family -- Roboto is loaded via next/font/google in layout.tsx */
-  --font-sans: var(--font-roboto), 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans:
+    var(--font-roboto), 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
   /* Colors -- Primary (Teal) */
   --color-primary: #2e8b8b;
@@ -39,10 +40,10 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f5f5f5;
   --color-bg-tertiary: #e5e5e5;
-  --color-bg-info: #DFF7FF;
-  --color-bg-error: #FFDFDF;
-  --color-bg-warning: #FFF6DF;
-  --color-bg-success: #E2FFC9;
+  --color-bg-info: #dff7ff;
+  --color-bg-error: #ffdfdf;
+  --color-bg-warning: #fff6df;
+  --color-bg-success: #e2ffc9;
 
   /* Colors -- Text */
   --color-text-primary: #333333;
@@ -50,16 +51,16 @@
   --color-text-tertiary: #999999;
   --color-text-disabled: #cccccc;
   --color-text-inverse: #ffffff;
-  --color-text-info: #448CBB;
-  --color-text-error: #D86666;
-  --color-text-warning: #BB7844;
-  --color-text-success: #4F854C;
+  --color-text-info: #448cbb;
+  --color-text-error: #d86666;
+  --color-text-warning: #bb7844;
+  --color-text-success: #4f854c;
 
   /* Colors -- Outline */
-  --color-outline-info: #88C6FF;
-  --color-outline-error: #FF8989;
-  --color-outline-warning: #FFCA4E;
-  --color-outline-success: #99C763;
+  --color-outline-info: #88c6ff;
+  --color-outline-error: #ff8989;
+  --color-outline-warning: #ffca4e;
+  --color-outline-success: #99c763;
 
   /* Colors - Form/Input Field */
   --color-input-primary: #707070;
@@ -84,6 +85,10 @@
   --color-button-idle-hovered: #6c757d;
   --color-button-positive-hovered: #178764;
   --color-button-negative-hovered: #bb4444;
+
+  /* Colors -- Skeleton */
+  --color-skeleton: #d9d9d9;
+  /* --color-skeleton-shimmer: #f0f0f0; */
 
   /* Font Sizes */
   --text-xs: 0.75rem;

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -25,11 +25,20 @@ const meta: Meta<typeof Skeleton> = {
 export default meta;
 type Story = StoryObj<typeof Skeleton>;
 
-export const Default: Story = {
-  args: {
-    animation: 'wave',
-    width: '100%',
-    height: 16,
-    radius: 'md',
-  },
+export const Default: Story = {};
+
+export const Card: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Skeleton height="70px" width="70px" radius="full" />
+      <Skeleton />
+      <Skeleton width="75%" />
+      <Skeleton width="50%" />
+      <Skeleton width="60%" />
+      <div className="flex gap-2">
+        <Skeleton height="25px" width="25px" />
+        <Skeleton height="25px" width="100px" />
+      </div>
+    </div>
+  ),
 };

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import Skeleton from './Skeleton';
+import { Card } from '../Card';
 
 const meta: Meta<typeof Skeleton> = {
   title: 'Components/Skeleton',
@@ -34,19 +35,23 @@ export const Default: Story = {
   },
 };
 
-export const Card: Story = {
+export const CardExample: Story = {
   render: () => (
-    <div className="p-8 flex justify-center items-center bg-bg-secondary">
-      <div className="flex flex-col gap-4 w-lg p-4 rounded-md bg-bg-primary shadow-md">
-        <Skeleton height={70} width={70} radius="full" />
-        <Skeleton />
-        <Skeleton width="75%" />
-        <Skeleton width="50%" />
-        <Skeleton width="60%" />
-        <div className="flex gap-2">
-          <Skeleton height={25} width={25} />
-          <Skeleton height={25} width={100} />
-        </div>
+    <div className="p-8 bg-bg-secondary flex justify-center items-center">
+      <div className="w-full sm:w-lg">
+        <Card>
+          <div className="flex flex-col gap-4">
+            <Skeleton height={70} width={70} radius="full" />
+            <Skeleton />
+            <Skeleton width="75%" />
+            <Skeleton width="50%" />
+            <Skeleton width="60%" />
+            <div className="flex gap-2">
+              <Skeleton height={25} width={25} />
+              <Skeleton height={25} width={100} />
+            </div>
+          </div>
+        </Card>
       </div>
     </div>
   ),

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Skeleton from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  argTypes: {
+    animation: {
+      options: ['wave', 'pulse', false],
+      control: {
+        type: 'radio',
+      },
+    },
+    radius: {
+      options: ['none', 'xs', 'sm', 'md', 'lg', 'full'],
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    animation: 'wave',
+    width: '100%',
+    height: 16,
+    radius: 'md',
+  },
+};

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -37,14 +37,14 @@ export const Default: Story = {
 export const Card: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <Skeleton height="70px" width="70px" radius="full" />
+      <Skeleton height={70} width={70} radius="full" />
       <Skeleton />
       <Skeleton width="75%" />
       <Skeleton width="50%" />
       <Skeleton width="60%" />
       <div className="flex gap-2">
-        <Skeleton height="25px" width="25px" />
-        <Skeleton height="25px" width="100px" />
+        <Skeleton height={25} width={25} />
+        <Skeleton height={25} width={100} />
       </div>
     </div>
   ),

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -36,16 +36,45 @@ export const Default: Story = {
 
 export const Card: Story = {
   render: () => (
-    <div className="flex flex-col gap-4">
-      <Skeleton height={70} width={70} radius="full" />
-      <Skeleton />
-      <Skeleton width="75%" />
-      <Skeleton width="50%" />
-      <Skeleton width="60%" />
-      <div className="flex gap-2">
-        <Skeleton height={25} width={25} />
-        <Skeleton height={25} width={100} />
+    <div className="p-8 flex justify-center items-center bg-bg-secondary">
+      <div className="flex flex-col gap-4 w-lg p-4 rounded-md bg-bg-primary shadow-md">
+        <Skeleton height={70} width={70} radius="full" />
+        <Skeleton />
+        <Skeleton width="75%" />
+        <Skeleton width="50%" />
+        <Skeleton width="60%" />
+        <div className="flex gap-2">
+          <Skeleton height={25} width={25} />
+          <Skeleton height={25} width={100} />
+        </div>
       </div>
     </div>
   ),
+};
+
+export const AnimationWave: Story = {
+  args: {
+    animation: 'wave',
+    width: 300,
+    height: 100,
+    radius: 'lg',
+  },
+};
+
+export const AnimationPulse: Story = {
+  args: {
+    animation: 'pulse',
+    width: 300,
+    height: 100,
+    radius: 'lg',
+  },
+};
+
+export const AnimationNone: Story = {
+  args: {
+    animation: false,
+    width: 300,
+    height: 100,
+    radius: 'lg',
+  },
 };

--- a/frontend/src/components/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof Skeleton> = {
       },
     },
     radius: {
-      options: ['none', 'xs', 'sm', 'md', 'lg', 'full'],
+      options: ['none', 'sm', 'base', 'md', 'lg', 'full'],
       control: {
         type: 'radio',
       },
@@ -25,7 +25,14 @@ const meta: Meta<typeof Skeleton> = {
 export default meta;
 type Story = StoryObj<typeof Skeleton>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    animation: 'wave',
+    width: '100%',
+    height: 16,
+    radius: 'base',
+  },
+};
 
 export const Card: Story = {
   render: () => (

--- a/frontend/src/components/Skeleton/Skeleton.styles.ts
+++ b/frontend/src/components/Skeleton/Skeleton.styles.ts
@@ -1,16 +1,17 @@
 import { tv } from 'tailwind-variants';
 
 export const skeletonStyles = tv({
-  base: 'block bg-skeleton cursor-progress rounded-md',
+  base: 'block bg-skeleton cursor-progress',
   variants: {
     animation: {
       pulse: 'animate-pulse',
       wave: 'animate-wave',
+      false: 'animate-none',
     },
     radius: {
       none: 'rounded-none',
-      xs: 'rounded-xs',
       sm: 'rounded-sm',
+      base: 'rounded-base',
       md: 'rounded-md',
       lg: 'rounded-lg',
       full: 'rounded-full',

--- a/frontend/src/components/Skeleton/Skeleton.styles.ts
+++ b/frontend/src/components/Skeleton/Skeleton.styles.ts
@@ -1,0 +1,25 @@
+import { tv } from 'tailwind-variants';
+
+export const skeletonStyles = tv({
+  base: 'block bg-skeleton cursor-progress ',
+  variants: {
+    animation: {
+      pulse: 'animate-pulse',
+      wave: 'animate-wave',
+    },
+    width: {
+      full: 'w-full',
+    },
+    height: {
+      full: 'h-full',
+    },
+    radius: {
+      none: 'rounded-none',
+      xs: 'rounded-xs',
+      sm: 'rounded-sm',
+      md: 'rounded-md',
+      lg: 'rounded-lg',
+      full: 'rounded-full',
+    },
+  },
+});

--- a/frontend/src/components/Skeleton/Skeleton.styles.ts
+++ b/frontend/src/components/Skeleton/Skeleton.styles.ts
@@ -1,17 +1,11 @@
 import { tv } from 'tailwind-variants';
 
 export const skeletonStyles = tv({
-  base: 'block bg-skeleton cursor-progress ',
+  base: 'block bg-skeleton cursor-progress rounded-md',
   variants: {
     animation: {
       pulse: 'animate-pulse',
       wave: 'animate-wave',
-    },
-    width: {
-      full: 'w-full',
-    },
-    height: {
-      full: 'h-full',
     },
     radius: {
       none: 'rounded-none',

--- a/frontend/src/components/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { SkeletonProps } from './Skeleton.types';
+import { skeletonStyles } from './Skeleton.styles';
+
+const Skeleton = ({
+  animation = 'wave',
+  width = '100%',
+  height = 16,
+  radius = 'md',
+  ...rest
+}: SkeletonProps) => {
+  return (
+    <span
+      {...rest}
+      className={skeletonStyles({ animation, width, height, radius })}
+      aria-hidden="true"
+    />
+  );
+};
+
+export default Skeleton;

--- a/frontend/src/components/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.tsx
@@ -1,23 +1,22 @@
 'use client';
-
 import type { SkeletonProps } from './Skeleton.types';
 import { skeletonStyles } from './Skeleton.styles';
+import { forwardRef } from 'react';
 
-const Skeleton = ({
-  animation = 'wave',
-  width = '100%',
-  height = 16,
-  radius = 'md',
-  ...rest
-}: SkeletonProps) => {
-  return (
-    <span
-      {...rest}
-      className={skeletonStyles({ animation, radius })}
-      style={{ width, height }}
-      aria-hidden="true"
-    />
-  );
-};
+const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
+  ({ animation = 'wave', width = '100%', height = 16, radius = 'base', ...rest }, ref) => {
+    return (
+      <span
+        ref={ref}
+        {...rest}
+        className={skeletonStyles({ animation, radius })}
+        style={{ width, height }}
+        aria-hidden="true"
+      />
+    );
+  }
+);
+
+Skeleton.displayName = 'Skeleton';
 
 export default Skeleton;

--- a/frontend/src/components/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/Skeleton/Skeleton.tsx
@@ -13,7 +13,8 @@ const Skeleton = ({
   return (
     <span
       {...rest}
-      className={skeletonStyles({ animation, width, height, radius })}
+      className={skeletonStyles({ animation, radius })}
+      style={{ width, height }}
       aria-hidden="true"
     />
   );

--- a/frontend/src/components/Skeleton/Skeleton.types.ts
+++ b/frontend/src/components/Skeleton/Skeleton.types.ts
@@ -25,12 +25,13 @@ interface SkeletonProps extends React.HTMLAttributes<HTMLSpanElement> {
   height?: number | string;
   /**
    * Border radius of the skeleton.
-   * - `none` — 0px
-   * - `sm` — 2px (0.125rem)
-   * - `base` — 4px (0.25rem)
-   * - `md` — 6px
-   * - `lg` — 8px
-   * - `full` — 9999px (circle / pill)
+   * Values map to design tokens defined in `src/assets/css/global.css`.
+   * - `none` — `--radius-none`
+   * - `sm` — `--radius-sm`
+   * - `base` — `--radius-base`
+   * - `md` — `--radius-md`
+   * - `lg` — `--radius-lg`
+   * - `full` — `--radius-full`
    * @default 'base'
    * @example
    * <Skeleton radius="full" />  // circular avatar placeholder

--- a/frontend/src/components/Skeleton/Skeleton.types.ts
+++ b/frontend/src/components/Skeleton/Skeleton.types.ts
@@ -1,0 +1,8 @@
+interface SkeletonProps extends React.HTMLAttributes<HTMLSpanElement> {
+  animation?: string | boolean; // 'pulse' | 'wave' | false. 'wave' is default.
+  width?: number | string; // '100%'	If number, treat as pixels. 100% is default.
+  height?: number | string; // '100%'	If number, treat as pixels. 16 is default.
+  radius?: string; // 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'full'. 'md' is default.
+}
+
+export type { SkeletonProps };

--- a/frontend/src/components/Skeleton/Skeleton.types.ts
+++ b/frontend/src/components/Skeleton/Skeleton.types.ts
@@ -1,8 +1,42 @@
 interface SkeletonProps extends React.HTMLAttributes<HTMLSpanElement> {
-  animation?: string | boolean; // 'pulse' | 'wave' | false. 'wave' is default.
-  width?: number | string; // '100%'	If number, treat as pixels. 100% is default.
-  height?: number | string; // '100%'	If number, treat as pixels. 16 is default.
-  radius?: string; // 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'full'. 'md' is default.
+  /**
+   * Animation style of the skeleton. Set to `false` to disable animation.
+   * @default 'wave'
+   * @example
+   * <Skeleton animation="pulse" />
+   * <Skeleton animation={false} />
+   */
+  animation?: 'wave' | 'pulse' | false;
+  /**
+   * Width of the skeleton. Numbers are treated as pixels, strings as CSS values.
+   * @default '100%'
+   * @example
+   * <Skeleton width={200} />
+   * <Skeleton width="50%" />
+   */
+  width?: number | string;
+  /**
+   * Height of the skeleton. Numbers are treated as pixels, strings as CSS values.
+   * @default 16
+   * @example
+   * <Skeleton height={40} />
+   * <Skeleton height="2rem" />
+   */
+  height?: number | string;
+  /**
+   * Border radius of the skeleton.
+   * - `none` — 0px
+   * - `sm` — 2px (0.125rem)
+   * - `base` — 4px (0.25rem)
+   * - `md` — 6px
+   * - `lg` — 8px
+   * - `full` — 9999px (circle / pill)
+   * @default 'base'
+   * @example
+   * <Skeleton radius="full" />  // circular avatar placeholder
+   * <Skeleton radius="none" />  // sharp-edged block
+   */
+  radius?: 'none' | 'sm' | 'base' | 'md' | 'lg' | 'full';
 }
 
 export type { SkeletonProps };

--- a/frontend/src/components/Skeleton/index.ts
+++ b/frontend/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { default as Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton.types';


### PR DESCRIPTION
- Closes #34 
- New `Skeleton` component with `wave`, `pulse`, and `false` (no-animation) modes.
- Supports `width`, `height` (number or string), and `radius` (mapped to existing design tokens — options are `none | sm | base | md | lg | full`; note: no `xs`, replaced by `base` to align with the token scale in `global.css`).
- Forwards refs, extends `React.HTMLAttributes<HTMLSpanElement>` to match the component's `<span>` element, sets `aria-hidden="true"`.
- Added `animate-wave` keyframe and `bg-skeleton` token to `global.css`. For `pulse` used Tailwind built-in `animate-pulse`. 
- Storybook stories including multi-skeleton card usage example.


