### PR TITLE
feat: update User model with auth fields and Role enum

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,9 +11,17 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  name      String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id           String   @id @default(uuid())
+  email        String   @unique
+  firstName    String
+  lastName     String
+  passwordHash String
+  role         Role     @default(USER)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+enum Role {
+  USER
+  ADMIN
 }

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -11,7 +11,12 @@ export class UserService {
     });
   }
 
-  async createUser(data: { email: string; firstName: string; lastName: string; passwordHash: string }) {
+  async createUser(data: {
+    email: string;
+    firstName: string;
+    lastName: string;
+    passwordHash: string;
+  }) {
     return await prisma.user.create({
       data,
     });

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -11,13 +11,13 @@ export class UserService {
     });
   }
 
-  async createUser(data: { email: string; name?: string }) {
+  async createUser(data: { email: string; firstName: string; lastName: string; passwordHash: string }) {
     return await prisma.user.create({
       data,
     });
   }
 
-  async updateUser(id: string, data: { email?: string; name?: string }) {
+  async updateUser(id: string, data: { email?: string; firstName?: string; lastName?: string }) {
     return await prisma.user.update({
       where: { id },
       data,


### PR DESCRIPTION
- resolves #29

Update User model with auth fields and Role enum

What changed
- Replaced name field with firstName and lastName
- Added passwordHash field to store bcrypt-hashed passwords
- Added role field with Role enum (USER / ADMIN), defaults to USER
- Updated userService.ts to match the new schema fields

Why
To support user authentication in upcoming tasks. Passwords will never be stored in plain text — passwordHash will hold the bcrypt result.

Steps to apply
bash
npm run prisma:push
npm run prisma:generate