### PR TITLE
add error handling middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.18.2",
+        "express-async-errors": "^3.1.1",
         "helmet": "^8.1.0"
       },
       "devDependencies": {
@@ -2350,6 +2351,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "helmet": "^8.1.0"
   },
   "devDependencies": {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -16,7 +16,9 @@ async function main() {
     update: {},
     create: {
       email: 'test@example.com',
-      name: 'Test User',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      passwordHash: 'hashedpassword123',
     },
   });
 

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -5,70 +5,40 @@ const userService = new UserService();
 
 export class UserController {
   async getUsers(req: Request, res: Response) {
-    try {
-      const users = await userService.getAllUsers();
-
-      res.json({ users });
-    } catch (error) {
-      console.error('Error fetching users:', error);
-
-      res.status(500).json({ error: 'Failed to fetch users' });
-    }
+    const users = await userService.getAllUsers();
+    res.json({ users });
   }
 
   async getUserById(req: Request, res: Response) {
-    try {
-      const { id } = req.params;
-      const user = await userService.getUserById(id);
+    const { id } = req.params;
+    const user = await userService.getUserById(id);
 
-      if (!user) {
-        return res.status(404).json({ error: 'User not found' });
-      }
-
-      res.json({ user });
-    } catch (error) {
-      console.error('Error fetching user:', error);
-      res.status(500).json({ error: 'Failed to fetch user' });
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
     }
+
+    res.json({ user });
   }
 
   async createUser(req: Request, res: Response) {
-    try {
-      const body = req.body;
-      const user = await userService.createUser(body);
+    const body = req.body;
+    const user = await userService.createUser(body);
 
-      res.status(201).json({ user });
-    } catch (error) {
-      console.error('Error creating user:', error);
-
-      res.status(500).json({ error: 'Failed to create user' });
-    }
+    res.status(201).json({ user });
   }
 
   async updateUser(req: Request, res: Response) {
-    try {
-      const { id } = req.params;
-      const body = req.body;
-      const user = await userService.updateUser(id, body);
+    const { id } = req.params;
+    const body = req.body;
+    const user = await userService.updateUser(id, body);
 
-      res.json({ user });
-    } catch (error) {
-      console.error('Error updating user:', error);
-
-      res.status(500).json({ error: 'Failed to update user' });
-    }
+    res.json({ user });
   }
 
   async deleteUser(req: Request, res: Response) {
-    try {
-      const { id } = req.params;
-      await userService.deleteUser(id);
+    const { id } = req.params;
+    await userService.deleteUser(id);
 
-      res.json({ message: 'User deleted successfully' });
-    } catch (error) {
-      console.error('Error deleting user:', error);
-
-      res.status(500).json({ error: 'Failed to delete user' });
-    }
+    res.json({ message: 'User deleted successfully' });
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import userRouter from './routes/userRoutes.js';
+import { notFound, errorHandler } from './middleware/errorHandler.js';
 
 const app = express();
 
@@ -43,6 +44,10 @@ app.use('/users', userRouter);
 app.get('/', (req: Request, res: Response) => {
   res.json({ status: 'ReDi Events API is running' });
 });
+
+// Error handling
+app.use(notFound);
+app.use(errorHandler);
 
 const protocol = process.env.PROTOCOL ?? 'http';
 const host = process.env.HOST ?? 'localhost';

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from 'express';
+import 'express-async-errors';
 import helmet from 'helmet';
 import cors from 'cors';
 import userRouter from './routes/userRoutes.js';

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -8,23 +8,12 @@ export function notFound(req: Request, res: Response) {
 // Removing `next` silently breaks error handling — Express would treat this as regular middleware instead.
 
 export function errorHandler(
-  err: Error & {
-    code?: string;
-  },
+  err: Error,
   req: Request,
   res: Response,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction
 ) {
   console.error('Error:', err);
-
-  if (err.code === 'P2025') {
-    return res.status(404).json({ error: 'Record not found' });
-  }
-
-  if (err.code === 'P2002') {
-    return res.status(409).json({ error: 'Duplicate value' });
-  }
-
   return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -4,6 +4,9 @@ export function notFound(req: Request, res: Response) {
   res.status(404).json({ error: 'Page not found' });
 }
 
+// ESLint ignore required: Express detects error-handling middleware by its 4-parameter signature (err, req, res, next).
+// Removing `next` silently breaks error handling — Express would treat this as regular middleware instead.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
   console.error('Error:', err);
   res.status(500).json({ error: 'Something went wrong' });

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -8,6 +8,6 @@ export function notFound(req: Request, res: Response) {
 // Removing `next` silently breaks error handling — Express would treat this as regular middleware instead.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
-  console.error('Error:', err);
+  console.error('Error:', err.stack);
   return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,10 @@
+import { NextFunction, Request, Response } from 'express';
+
+export function notFound(req: Request, res: Response) {
+  res.status(404).json({ error: 'Page not found' });
+}
+
+export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
+  console.error('Error:', err);
+  res.status(500).json({ error: 'Something went wrong' });
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 
 export function notFound(req: Request, res: Response) {
-  res.status(404).json({ error: 'Page not found' });
+  return res.status(404).json({ error: 'Page not found' });
 }
 
 // ESLint ignore required: Express detects error-handling middleware by its 4-parameter signature (err, req, res, next).
@@ -9,5 +9,5 @@ export function notFound(req: Request, res: Response) {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
   console.error('Error:', err);
-  res.status(500).json({ error: 'Something went wrong' });
+  return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -7,7 +7,7 @@ export function notFound(req: Request, res: Response) {
 // ESLint ignore required: Express detects error-handling middleware by its 4-parameter signature (err, req, res, next).
 // Removing `next` silently breaks error handling — Express would treat this as regular middleware instead.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
+export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
   console.error('Error:', err);
   res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -6,8 +6,25 @@ export function notFound(req: Request, res: Response) {
 
 // ESLint ignore required: Express detects error-handling middleware by its 4-parameter signature (err, req, res, next).
 // Removing `next` silently breaks error handling — Express would treat this as regular middleware instead.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
-  console.error('Error:', err.stack);
+
+export function errorHandler(
+  err: Error & {
+    code?: string;
+  },
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  next: NextFunction
+) {
+  console.error('Error:', err);
+
+  if (err.code === 'P2025') {
+    return res.status(404).json({ error: 'Record not found' });
+  }
+
+  if (err.code === 'P2002') {
+    return res.status(409).json({ error: 'Duplicate value' });
+  }
+
   return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -4,7 +4,7 @@ export function notFound(req: Request, res: Response) {
   res.status(404).json({ error: 'Page not found' });
 }
 
-export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
+export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
   console.error('Error:', err);
   res.status(500).json({ error: 'Something went wrong' });
 }


### PR DESCRIPTION
- closes #43 
- Added **notFound** and **errorHandler** middleware in backend/src/middleware/errorHandler.ts
- Registered both middleware at the end of the Express app in index.ts (after all routes)
- Added `express-async-errors` to patch Express 4's missing async error propagation. Async errors thrown in controllers are now automatically forwarded to the error handler middleware, matching Express 5 behavior.