### PR TITLE
feat: add event model with user relation

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,20 @@ model User {
   role         Role     @default(USER)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  events       Event[]
+}
+
+model Event {
+  id          String   @id @default(uuid())
+  title       String
+  description String?
+  date        DateTime
+  location    String
+  capacity    Int
+  organizerId String
+  organizer   User     @relation(fields: [organizerId], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 enum Role {


### PR DESCRIPTION
resolves #47 

## Summary
Adds the `Event` model to the Prisma schema and links it to the `User` model.

## Changes
- Added `Event` model with `title`, `description`, `date`, `location`, and `capacity`
- Added relation between `Event` and `User` via `organizerId`
- Added `events` field to the `User` model

## How to Test
- Run `npm run prisma:push`
- Run `npm run prisma:generate`
- Run `npm run prisma:studio`
- Verify that the `Event` table appears in Prisma Studio

## Notes
`organizerId` is a foreign key referencing `User.id`.