### PR TITLE
48 list all events get events

### DIFF
--- a/backend/src/controllers/eventController.ts
+++ b/backend/src/controllers/eventController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { EventService } from 'src/services/eventService.js';
+import { NextFunction } from 'express';
 
 const eventService = new EventService();
 
@@ -13,23 +14,16 @@ function parseEventFilter(value: unknown): EventFilter | undefined {
 }
 
 export class EventController {
-  async getEvents(req: Request, res: Response) {
+  async getEvents(req: Request, res: Response, next: NextFunction) {
     try {
       const filter = parseEventFilter(req.query.filter);
       const events = await eventService.getEvents(filter);
       res.json({ events });
-    } catch (error) {
-      if (error instanceof Error && error.message === 'INVALID_EVENT_FILTER') {
-        return res.status(400).json({
-          error: 'Invalid filter. Use "upcoming" or "past".',
-        });
-      }
-
-      console.error('Error fetching events:', error);
-
-      res.status(500).json({
-        error: 'Failed to fetch events',
-      });
+    } catch (err) {
+      console.log('Error caught:', err);
+      console.log('Error type:', err instanceof Error);
+      console.log('Error message:', (err as Error).message);
+      next(err);
     }
   }
 }

--- a/backend/src/controllers/eventController.ts
+++ b/backend/src/controllers/eventController.ts
@@ -3,30 +3,33 @@ import { EventService } from 'src/services/eventService.js';
 
 const eventService = new EventService();
 
-type EventFilter = 'upcoming' | 'past' | undefined;
+type EventFilter = 'upcoming' | 'past';
 
-function isEventFilter(value: unknown): value is EventFilter {
-  return value === 'upcoming' || value === 'past' || value === undefined;
+function parseEventFilter(value: unknown): EventFilter | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'upcoming' || value === 'past') return value;
+
+  throw new Error('INVALID_EVENT_FILTER');
 }
 
 export class EventController {
   async getEvents(req: Request, res: Response) {
     try {
-      const rawFilter = req.query.filter;
-
-      if (rawFilter && !isEventFilter(rawFilter)) {
-        return res.status(400).json({ error: 'Invalid filter. Use "upcoming" or "past".' });
-      }
-
-      const filter = rawFilter === 'upcoming' || rawFilter === 'past' ? rawFilter : undefined;
-
+      const filter = parseEventFilter(req.query.filter);
       const events = await eventService.getEvents(filter);
-
       res.json({ events });
     } catch (error) {
+      if (error instanceof Error && error.message === 'INVALID_EVENT_FILTER') {
+        return res.status(400).json({
+          error: 'Invalid filter. Use "upcoming" or "past".',
+        });
+      }
+
       console.error('Error fetching events:', error);
 
-      res.status(500).json({ error: 'Failed to fetch events' });
+      res.status(500).json({
+        error: 'Failed to fetch events',
+      });
     }
   }
 }

--- a/backend/src/controllers/eventController.ts
+++ b/backend/src/controllers/eventController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { EventService } from 'src/services/eventService.js';
+
+const eventService = new EventService();
+
+type EventFilter = 'upcoming' | 'past' | undefined;
+
+function isEventFilter(value: unknown): value is EventFilter {
+  return value === 'upcoming' || value === 'past' || value === undefined;
+}
+
+export class EventController {
+  async getEvents(req: Request, res: Response) {
+    try {
+      const rawFilter = req.query.filter;
+
+      if (rawFilter && !isEventFilter(rawFilter)) {
+        return res.status(400).json({ error: 'Invalid filter. Use "upcoming" or "past".' });
+      }
+
+      const filter = rawFilter === 'upcoming' || rawFilter === 'past' ? rawFilter : undefined;
+
+      const events = await eventService.getEvents(filter);
+
+      res.json({ events });
+    } catch (error) {
+      console.error('Error fetching events:', error);
+
+      res.status(500).json({ error: 'Failed to fetch events' });
+    }
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import userRouter from './routes/userRoutes.js';
+import eventRouter from './routes/eventRoutes.js';
 
 const app = express();
 
@@ -38,6 +39,7 @@ app.use(
 
 // Routes
 app.use('/users', userRouter);
+app.use('/events', eventRouter);
 
 // Health check
 app.get('/', (req: Request, res: Response) => {

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -15,5 +15,10 @@ export function errorHandler(
   next: NextFunction
 ) {
   console.error('Error:', err);
+
+  if (err.message === 'INVALID_EVENT_FILTER') {
+    return res.status(400).json({ error: 'Invalid event filter' });
+  }
+
   return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/routes/eventRoutes.ts
+++ b/backend/src/routes/eventRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { EventController } from 'src/controllers/eventController.js';
+
+const eventController = new EventController();
+const eventRouter = Router();
+
+eventRouter.get('/', (req, res) => eventController.getEvents(req, res));
+
+export default eventRouter;

--- a/backend/src/routes/eventRoutes.ts
+++ b/backend/src/routes/eventRoutes.ts
@@ -4,6 +4,6 @@ import { EventController } from 'src/controllers/eventController.js';
 const eventController = new EventController();
 const eventRouter = Router();
 
-eventRouter.get('/', (req, res) => eventController.getEvents(req, res));
+eventRouter.get('/', (req, res, next) => eventController.getEvents(req, res, next));
 
 export default eventRouter;

--- a/backend/src/services/eventService.ts
+++ b/backend/src/services/eventService.ts
@@ -1,0 +1,33 @@
+import prisma from 'src/libs/prisma.js';
+import { Prisma } from 'generated/prisma/client.js';
+export class EventService {
+  async getEvents(filter?: 'upcoming' | 'past') {
+    // If filter is 'upcoming', return events where date is in the future
+    // If filter is 'past', return events where date is in the past
+    // Otherwise return all events
+    // Hint: use a `where` clause with Prisma's `gt` (greater than) and `lt` (less than) operators
+    /** your logic goes here **/
+    const currentDate = new Date();
+
+    const where: Prisma.EventWhereInput | undefined =
+      filter === 'upcoming'
+        ? { date: { gt: currentDate } }
+        : filter === 'past'
+          ? { date: { lt: currentDate } }
+          : undefined;
+
+    const events = await prisma.event.findMany({
+      where,
+      include: {
+        organizer: {
+          select: {
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    });
+
+    return events;
+  }
+}

--- a/backend/src/services/eventService.ts
+++ b/backend/src/services/eventService.ts
@@ -2,11 +2,6 @@ import prisma from 'src/libs/prisma.js';
 import { Prisma } from 'generated/prisma/client.js';
 export class EventService {
   async getEvents(filter?: 'upcoming' | 'past') {
-    // If filter is 'upcoming', return events where date is in the future
-    // If filter is 'past', return events where date is in the past
-    // Otherwise return all events
-    // Hint: use a `where` clause with Prisma's `gt` (greater than) and `lt` (less than) operators
-    /** your logic goes here **/
     const currentDate = new Date();
 
     const where: Prisma.EventWhereInput | undefined =


### PR DESCRIPTION
- Closes #48 

## Summary
Implemented optional date filtering for the `GET /events` endpoint.

Users can now filter events by whether they are upcoming or past using the `filter` query parameter.

## Changes Made
- Added `EventService.getEvents(filter?)` with Prisma date filtering
- Added support for:
  - `GET /events`
  - `GET /events?filter=upcoming`
  - `GET /events?filter=past`
- Added validation for invalid filter values
- Return `400 Bad Request` for unsupported filters
- Included organizer `firstName` and `lastName` in event responses
- Added event routes and registered them in `index.ts`

## Accepted Filters
- `upcoming`
- `past`

## Invalid Filter Behavior
Requests with invalid filter values return:

```json
{
  "error": "Invalid filter. Use \"upcoming\" or \"past\"."
}