### PR TITLE
Feature update own profile

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -29,6 +29,11 @@ export class UserController {
 
   async updateUser(req: Request, res: Response) {
     const { id } = req.params;
+
+    if (!req.user || req.user.userId !== id) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
     const body = req.body;
     const user = await userService.updateUser(id, body);
 

--- a/backend/src/dto/user.dto.ts
+++ b/backend/src/dto/user.dto.ts
@@ -1,0 +1,15 @@
+import { User } from '@prisma/client';
+
+export class UserDTO {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+
+  constructor(user: User) {
+    this.id = user.id;
+    this.email = user.email;
+    this.firstName = user.firstName;
+    this.lastName = user.lastName;
+  }
+}

--- a/backend/src/dto/user.dto.ts
+++ b/backend/src/dto/user.dto.ts
@@ -1,12 +1,10 @@
-import { User } from '@prisma/client';
-
 export class UserDTO {
   id: string;
   email: string;
   firstName: string;
   lastName: string;
 
-  constructor(user: User) {
+  constructor(user: { id: string; email: string; firstName: string; lastName: string }) {
     this.id = user.id;
     this.email = user.email;
     this.firstName = user.firstName;

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -37,10 +37,12 @@ export class UserService {
   }
 
   async updateUser(id: string, data: { email?: string; firstName?: string; lastName?: string }) {
-    return await prisma.user.update({
+    const user = await prisma.user.update({
       where: { id },
       data,
     });
+    const { passwordHash, ...safeUser } = user;
+    return safeUser;
   }
 
   async deleteUser(id: string) {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -1,5 +1,6 @@
 import prisma from '../libs/prisma.js';
 import bcrypt from 'bcrypt';
+import { UserDTO } from '../dto/user.dto.js';
 
 export class UserService {
   async getAllUsers() {
@@ -41,8 +42,7 @@ export class UserService {
       where: { id },
       data,
     });
-    const { passwordHash, ...safeUser } = user;
-    return safeUser;
+    return new UserDTO(user);
   }
 
   async deleteUser(id: string) {


### PR DESCRIPTION
Closes #45
This PR implements the user profile update feature with proper authorization control.

## Implemented changes
- Users can update only their own profile (firstName, lastName)
- Returns 403 Forbidden when attempting to update another user's profile
- Password hash is excluded from API response

## Notes on task scope
Some parts of the original task were already implemented in the codebase:

- 401 Unauthorized handling (no token provided) is already implemented in `backend/src/middleware/authenticate.ts`
- Route is already wired with `authenticate` middleware
- The `updateUser` method in both controller and service already existed before this task

The feature was tested using Postman.