### PR TITLE
Feat/issue 96/create user account

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
 import { UserService } from '../services/userService.js';
 
 const userService = new UserService();
@@ -20,21 +20,11 @@ export class UserController {
     res.json({ user });
   }
 
-  async createUser(req: Request, res: Response, next: NextFunction) {
-    try {
-      const body = req.body;
-      const user = await userService.createUser(body);
+  async createUser(req: Request, res: Response) {
+    const body = req.body;
+    const user = await userService.createUser(body);
 
-      return res.status(201).json({ user });
-    } catch (error) {
-      if (error instanceof Error && error.message === 'EMAIL_ALREADY_IN_USE') {
-        return res.status(400).json({
-          error: 'Email is already in use',
-        });
-      }
-
-      next(error);
-    }
+    return res.status(201).json({ user });
   }
 
   async updateUser(req: Request, res: Response) {

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { UserService } from '../services/userService.js';
 
 const userService = new UserService();
@@ -20,11 +20,21 @@ export class UserController {
     res.json({ user });
   }
 
-  async createUser(req: Request, res: Response) {
-    const body = req.body;
-    const user = await userService.createUser(body);
+  async createUser(req: Request, res: Response, next: NextFunction) {
+    try {
+      const body = req.body;
+      const user = await userService.createUser(body);
 
-    res.status(201).json({ user });
+      return res.status(201).json({ user });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'EMAIL_ALREADY_IN_USE') {
+        return res.status(400).json({
+          error: 'Email is already in use',
+        });
+      }
+
+      next(error);
+    }
   }
 
   async updateUser(req: Request, res: Response) {

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -16,5 +16,9 @@ export function errorHandler(
 ) {
   console.error('Error:', err);
 
+  if (err.message === 'EMAIL_ALREADY_IN_USE') {
+    return res.status(400).json({ error: 'Email is already in use' });
+  }
+
   return res.status(500).json({ error: 'Something went wrong' });
 }

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -8,9 +8,7 @@ const userController = new UserController();
 const userRouter = Router();
 
 userRouter.get('/', (req, res) => userController.getUsers(req, res));
-userRouter.post('/', validate(registerSchema), (req, res, next) =>
-  userController.createUser(req, res, next)
-);
+userRouter.post('/', validate(registerSchema), (req, res) => userController.createUser(req, res));
 userRouter.get('/:id', (req, res) => userController.getUserById(req, res));
 userRouter.put('/:id', authenticate, (req, res) => userController.updateUser(req, res));
 userRouter.delete('/:id', authenticate, (req, res) => userController.deleteUser(req, res));

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -8,7 +8,9 @@ const userController = new UserController();
 const userRouter = Router();
 
 userRouter.get('/', (req, res) => userController.getUsers(req, res));
-userRouter.post('/', validate(registerSchema), (req, res) => userController.createUser(req, res));
+userRouter.post('/', validate(registerSchema), (req, res, next) =>
+  userController.createUser(req, res, next)
+);
 userRouter.get('/:id', (req, res) => userController.getUserById(req, res));
 userRouter.put('/:id', authenticate, (req, res) => userController.updateUser(req, res));
 userRouter.delete('/:id', authenticate, (req, res) => userController.deleteUser(req, res));

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { UserController } from '../controllers/userController.js';
 import { authenticate } from '../middleware/authenticate.js';
+import { validate } from '../middleware/validateUserInput.js';
+import { registerSchema } from '../validators/schemas.js';
 
 const userController = new UserController();
 const userRouter = Router();
 
 userRouter.get('/', (req, res) => userController.getUsers(req, res));
-userRouter.post('/', (req, res) => userController.createUser(req, res));
+userRouter.post('/', validate(registerSchema), (req, res) => userController.createUser(req, res));
 userRouter.get('/:id', (req, res) => userController.getUserById(req, res));
 userRouter.put('/:id', authenticate, (req, res) => userController.updateUser(req, res));
 userRouter.delete('/:id', authenticate, (req, res) => userController.deleteUser(req, res));

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -17,6 +17,14 @@ export class UserService {
   }
 
   async createUser(data: { email: string; firstName: string; lastName: string; password: string }) {
+    const existingUser = await prisma.user.findUnique({
+      where: { email: data.email },
+    });
+
+    if (existingUser) {
+      throw new Error('EMAIL_ALREADY_IN_USE');
+    }
+
     const passwordHash = await bcrypt.hash(data.password, 10);
     return await prisma.user.create({
       omit: {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -16,22 +16,18 @@ export class UserService {
     });
   }
 
-  async createUser(data: {
-    email: string;
-    firstName: string;
-    lastName: string;
-    password: string;
-    role?: 'USER' | 'ADMIN';
-  }) {
+  async createUser(data: { email: string; firstName: string; lastName: string; password: string }) {
     const passwordHash = await bcrypt.hash(data.password, 10);
-
     return await prisma.user.create({
+      omit: {
+        passwordHash: true,
+      },
       data: {
         email: data.email,
         firstName: data.firstName,
         lastName: data.lastName,
         passwordHash,
-        role: data.role ?? 'USER',
+        role: 'USER',
       },
     });
   }

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -17,9 +17,7 @@ export class UserService {
   }
 
   async createUser(data: { email: string; firstName: string; lastName: string; password: string }) {
-    const existingUser = await prisma.user.findUnique({
-      where: { email: data.email },
-    });
+    const existingUser = await this.findUserByEmail(data.email);
 
     if (existingUser) {
       throw new Error('EMAIL_ALREADY_IN_USE');
@@ -50,6 +48,12 @@ export class UserService {
   async deleteUser(id: string) {
     return await prisma.user.delete({
       where: { id },
+    });
+  }
+
+  async findUserByEmail(email: string) {
+    return prisma.user.findUnique({
+      where: { email },
     });
   }
 }


### PR DESCRIPTION
Closes #96

Implements account creation for `POST /users`.

#### Changes

- Validates the user registration request
- Hashes the password before saving the user
- Creates new users with the `USER` role
- Prevents duplicate email registration
- Returns the created user without exposing `passwordHash`