### PR TITLE
feat: exclude passwordHash from getAllUsers response

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -6,7 +6,7 @@ const userService = new UserService();
 export class UserController {
   async getUsers(req: Request, res: Response) {
     const users = await userService.getAllUsers();
-    res.json({ users });
+    res.status(200).json({ users });
   }
 
   async getUserById(req: Request, res: Response) {

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -4,7 +4,7 @@ import { UserDTO } from '../dto/user.dto.js';
 
 export class UserService {
   async getAllUsers() {
-    return await prisma.user.findMany();
+    return await prisma.user.findMany({ omit: { passwordHash: true } });
   }
 
   async getUserById(id: string) {


### PR DESCRIPTION
Resolves #97 

A user can request the list of users so the application can display user-related information where needed. The API returns public user data only.

What changed

Updated getAllUsers() in userService.ts to exclude passwordHash from every returned user using Prisma's omit option.

Why

To ensure the endpoint never exposes sensitive authentication data to the client.

Acceptance Criteria

- GET /users returns a list of users
- Each user includes id, firstName, lastName, email, and role
- Response does not include passwordHash
- Returns 200 with { users: [...] }
- Returns an empty array when no users exist