### PR TITLE
feat: replace mock user with real data via server-side auth context

### DIFF
--- a/frontend/src/app/(private)/layout.tsx
+++ b/frontend/src/app/(private)/layout.tsx
@@ -1,7 +1,31 @@
+import { cookies } from 'next/headers';
+import { decodeJwt } from 'jose';
 import { ProtectedLayout } from '@components';
+import { AuthProvider, AuthUser } from '@context/AuthContext';
+import { getUserById } from '@service/userService';
 
-const PrivateLayout = ({ children }: { children: React.ReactNode }) => {
-  return <ProtectedLayout>{children}</ProtectedLayout>;
+const PrivateLayout = async ({ children }: { children: React.ReactNode }) => {
+  let authUser: AuthUser | null = null;
+
+  try {
+    const token = (await cookies()).get('token')?.value;
+    if (!token) throw new Error('No token found');
+
+    const { userId, role } = decodeJwt<{ userId: string; role: 'USER' | 'ADMIN' }>(token);
+
+    const user = await getUserById(userId, token);
+    if (!user) throw new Error('Smth went wrong fetching user data');
+
+    authUser = { ...user, role };
+  } catch (err) {
+    console.error(err); // server-side only — logs to Node.js stdout, not the browser
+  }
+
+  return (
+    <AuthProvider initialUser={authUser}>
+      <ProtectedLayout>{children}</ProtectedLayout>
+    </AuthProvider>
+  );
 };
 
 export default PrivateLayout;

--- a/frontend/src/components/ProtectedLayout/ProtectedLayout.tsx
+++ b/frontend/src/components/ProtectedLayout/ProtectedLayout.tsx
@@ -4,9 +4,16 @@ import { Logo } from '../Logo';
 import { UserArea } from '@components';
 import useAuth from '@hooks/useAuth';
 import { Skeleton } from '@components/Skeleton';
+import { getInitials } from '@utils/utils';
+import { useAuthContext } from '@context/AuthContext';
 
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
-  const { user, loading, signOut, goToProfile } = useAuth();
+  const { loading, signOut, goToProfile } = useAuth();
+  const { authUser } = useAuthContext();
+
+  const userFullName = authUser ? `${authUser.firstName} ${authUser.lastName}` : '';
+  const userInitials = authUser ? getInitials(userFullName) : '';
+
   const { main, headerBar, content } = protectedLayoutStyles();
 
   return (
@@ -19,17 +26,17 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
         <div className="md:hidden">
           <Logo size="compact" />
         </div>
-        {loading ? (
+        {loading || !authUser ? (
           <div className="flex items-center gap-3">
             <Skeleton width={40} height={40} radius="full" />
             <div className="hidden md:block">
               <Skeleton width={100} height={16} radius="base" />
             </div>
           </div>
-        ) : user ? (
+        ) : authUser ? (
           <UserArea
-            userName={user.name}
-            avatarInitials={user.initials}
+            userName={userFullName}
+            avatarInitials={userInitials}
             onProfile={goToProfile}
             onSignOut={signOut}
           />

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -11,8 +11,8 @@ export interface AuthUser {
 }
 
 interface AuthContextValue {
-  authUser: AuthUser | null;
-  setAuthUser: (user: AuthUser | null) => void;
+  authUser: Readonly<AuthUser> | null;
+  clearAuthUser: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -25,8 +25,14 @@ interface AuthProviderProps {
 export const AuthProvider = ({ initialUser, children }: AuthProviderProps) => {
   const [authUser, setAuthUser] = useState<AuthUser | null>(initialUser);
 
-  return <AuthContext.Provider value={{ authUser, setAuthUser }}>{children}</AuthContext.Provider>;
+  const clearAuthUser = () => {
+    setAuthUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ authUser, clearAuthUser }}>{children}</AuthContext.Provider>
+  );
 };
 
 export const useAuthContext = (): AuthContextValue =>
-  useContext(AuthContext) ?? { authUser: null, setAuthUser: () => {} };
+  useContext(AuthContext) ?? { authUser: null, clearAuthUser: () => {} };

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: 'USER' | 'ADMIN';
+  firstName: string;
+  lastName: string;
+}
+
+interface AuthContextValue {
+  authUser: AuthUser | null;
+  setAuthUser: (user: AuthUser | null) => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  initialUser: AuthUser | null;
+  children: React.ReactNode;
+}
+
+export const AuthProvider = ({ initialUser, children }: AuthProviderProps) => {
+  const [authUser, setAuthUser] = useState<AuthUser | null>(initialUser);
+
+  return <AuthContext.Provider value={{ authUser, setAuthUser }}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = (): AuthContextValue =>
+  useContext(AuthContext) ?? { authUser: null, setAuthUser: () => {} };

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,24 +1,21 @@
 import { useState } from 'react';
+import { useAuthContext } from '@context/AuthContext';
 import { loginRequest } from '@service/authService';
 import { LoginInput } from '@validators/schemas';
-
-interface UserData {
-  name: string;
-  initials: string;
-}
-
-const MOCK_USER: UserData = { name: 'Fabio Rodrigues', initials: 'FR' };
+import { useRouter } from 'next/navigation';
 
 export default function useAuth() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
-  const [user, setUser] = useState<UserData | null>(MOCK_USER);
+  const { authUser } = useAuthContext();
+  const router = useRouter();
+
   const signOut = () => {
-    // TODO: Implement real sign-out logic
+    // TODO: clear cookie, then setAuthUser(null) + redirect
   };
 
   const goToProfile = () => {
-    // TODO: Implement navigation to profile page
+    if (authUser) router.push(`/profiles/${authUser.id}`); // update route when profile page is implemented
   };
 
   const signIn = async ({ email, password }: LoginInput) => {
@@ -40,5 +37,5 @@ export default function useAuth() {
     }
   };
 
-  return { signIn, loading, error, goToProfile, signOut, user, setUser };
+  return { signIn, loading, error, goToProfile, signOut };
 }

--- a/frontend/src/service/userService.ts
+++ b/frontend/src/service/userService.ts
@@ -1,0 +1,22 @@
+import { config } from '@config';
+
+export interface User {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+}
+
+export async function getUserById(id: string, token: string): Promise<User | null> {
+  const { apiUrl } = await config();
+
+  const res = await fetch(`${apiUrl}/users/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) return null;
+
+  const { user } = await res.json();
+
+  return { id: user.id, email: user.email, firstName: user.firstName, lastName: user.lastName };
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,6 +22,10 @@
       "@types": ["./src/types"],
       "@hooks/*": ["./src/hooks/*"],
       "@validators/*": ["./src/validators/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@utils": ["./src/utils"],
+      "@context/*": ["./src/context/*"],
+      "@context": ["./src/context"],
       "@/*": ["./src/*"]
     },
     "plugins": [


### PR DESCRIPTION
- Introduces AuthContext seeded by the private layout server component. On every navigation into private routes, the layout reads the JWT cookie, decodes userId/role, fetches user data from the API – all server side – and passes it to AuthProvider.
- Removed mock data passed to ProtectedLayout and replaced with actual authenticated user from global context
- Profile page route (goToProfile navigates to /profiles/:id, placeholder until profile page is built)