### PR TITLE
125 fix layout shift on 404 network error pages

### DIFF
--- a/frontend/src/app/(public)/network-error/NetworkErrorView.tsx
+++ b/frontend/src/app/(public)/network-error/NetworkErrorView.tsx
@@ -11,7 +11,7 @@ const NetworkErrorView = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-8 max-w-md text-center lg:items-start lg:text-left">
+    <div className="flex-1 flex flex-col items-center justify-center gap-8 max-w-md text-center lg:items-start lg:text-left">
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-normal text-text-primary">Something went wrong</h1>
         <p className="text-lg font-normal text-text-secondary">

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -19,7 +19,7 @@ const NotFound = () => {
 
   return (
     <PublicLayout>
-      <div className="flex w-full flex-col items-center justify-center gap-6 px-4 sm:px-6 lg:gap-10">
+      <div className="flex-1 flex w-full flex-col items-center justify-center gap-6 px-4 sm:px-6 lg:gap-10">
         <div className="flex w-full max-w-md flex-col items-center gap-8 lg:items-start">
           <div className="text-center lg:text-left">
             <h1 className="text-3xl font-normal leading-tight text-text-primary">

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 const PUBLIC_AUTH_PATHS = ['/sign-in', '/sign-up'];
+const ALWAYS_PUBLIC_PATHS = ['/network-error'];
 
 async function isValidToken(token: string): Promise<boolean> {
   const secret = process.env.JWT_SECRET;
@@ -19,6 +20,11 @@ async function isValidToken(token: string): Promise<boolean> {
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('token')?.value;
+
+  // bypass auth entirely — accessible to both authenticated and unauthenticated users
+  if (ALWAYS_PUBLIC_PATHS.some((path) => pathname.startsWith(path))) {
+    return NextResponse.next();
+  }
 
   const isAuthPath = PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
   const authenticated = token ? await isValidToken(token) : false;


### PR DESCRIPTION
- closes #125 

- Add flex-1 to the content wrapper on /network-error and /not-found so the layout fills the full height without shifting
- Move /network-error out of PUBLIC_AUTH_PATHS into a separate ALWAYS_PUBLIC_PATHS bypass in middleware, so the page is reachable by both authenticated and unauthenticated users (previously authenticated users were redirected to /events)

TEST by:

- visiting [/network-error](http://localhost:3000/network-error) - should open when both authenticated and not. 
- visiting any non-existent route (for 404 page)