### PR TITLE
137 update eventcard to seperate preview fullview modes

### DIFF
--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -84,6 +84,7 @@
   --color-ec-primary: #707070;
   --color-ec-secondary: #949ea8;
   --color-ec-tertiary: #7d7878;
+  --color-ec-title: #323c46;
 
   /* Colors -- Button */
   --color-button-idle: #75898c;

--- a/frontend/src/components/EventCard/EventCard.stories.tsx
+++ b/frontend/src/components/EventCard/EventCard.stories.tsx
@@ -2,21 +2,32 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import EventCard from './EventCard';
 
+const eventDetailsPlaceholder = {
+  id: '1',
+  date: new Date('2024-06-15T18:00:00Z'),
+  title: 'How to Network',
+  author: 'Jane Doe',
+  description:
+    'Let’s get together and share techniques on how to network and communicate well our interests.',
+  attendeeCount: 15,
+  maxAttendees: 30,
+};
+
 const meta: Meta<typeof EventCard> = {
   title: 'Components/EventCard',
   component: EventCard,
   tags: ['autodocs'],
   argTypes: {
+    variant: {
+      options: ['preview', 'fullview'],
+      control: { type: 'radio' },
+    },
     action: {
       options: ['join', 'leave', 'edit', 'archived'],
-      control: {
-        type: 'radio',
-      },
+      control: { type: 'radio' },
     },
     isActionPending: {
-      control: {
-        type: 'boolean',
-      },
+      control: { type: 'boolean' },
     },
   },
 };
@@ -27,14 +38,20 @@ type Story = StoryObj<typeof EventCard>;
 export const EventCardExample: Story = {
   args: {
     isLoading: false,
+    variant: 'preview',
     action: 'join',
-    date: new Date('2017-04-04T14:17:00Z'),
-    title: 'How to Network',
-    author: 'Owner',
-    description:
-      'Let’s get together and share techniques on how to network and communicate well our interests.',
-    attendeeCount: 10,
-    maxAttendees: 40,
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
+  },
+};
+
+export const Fullview: Story = {
+  args: {
+    isLoading: false,
+    variant: 'fullview',
+    action: 'join',
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
   },
 };
 
@@ -48,6 +65,8 @@ export const Join: Story = {
   args: {
     isLoading: false,
     action: 'join',
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
   },
 };
 
@@ -55,6 +74,8 @@ export const Leave: Story = {
   args: {
     isLoading: false,
     action: 'leave',
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
   },
 };
 
@@ -62,6 +83,8 @@ export const Edit: Story = {
   args: {
     isLoading: false,
     action: 'edit',
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
   },
 };
 
@@ -69,6 +92,8 @@ export const Archived: Story = {
   args: {
     isLoading: false,
     action: 'archived',
+    isActionPending: false,
+    ...eventDetailsPlaceholder,
   },
 };
 
@@ -77,12 +102,6 @@ export const ActionLoading: Story = {
     isLoading: false,
     action: 'join',
     isActionPending: true,
-    date: new Date('2017-04-04T14:17:00Z'),
-    title: 'How to Network',
-    author: 'Owner',
-    description:
-      'Let’s get together and share techniques on how to network and communicate well our interests.',
-    attendeeCount: 10,
-    maxAttendees: 40,
+    ...eventDetailsPlaceholder,
   },
 };

--- a/frontend/src/components/EventCard/EventCard.stories.tsx
+++ b/frontend/src/components/EventCard/EventCard.stories.tsx
@@ -8,7 +8,7 @@ const eventDetailsPlaceholder = {
   title: 'How to Network',
   author: 'Jane Doe',
   description:
-    'Let’s get together and share techniques on how to network and communicate well our interests. We’ll cover practical tips on introducing yourself, following up after meetings, using LinkedIn effectively, and building genuine long-term professional relationships in the tech industry.',
+    'Let’s get together and share techniques on how to network and communicate well our interests. We’ll cover practical tips on introducing yourself, following up after meetings, using LinkedIn effectively, and building genuine long-term professional relationships in the tech industry.\n\nLight refreshments provided. All levels welcome.',
   attendeeCount: 15,
   maxAttendees: 30,
 };

--- a/frontend/src/components/EventCard/EventCard.stories.tsx
+++ b/frontend/src/components/EventCard/EventCard.stories.tsx
@@ -8,7 +8,7 @@ const eventDetailsPlaceholder = {
   title: 'How to Network',
   author: 'Jane Doe',
   description:
-    'Let’s get together and share techniques on how to network and communicate well our interests.',
+    'Let’s get together and share techniques on how to network and communicate well our interests. We’ll cover practical tips on introducing yourself, following up after meetings, using LinkedIn effectively, and building genuine long-term professional relationships in the tech industry.',
   attendeeCount: 15,
   maxAttendees: 30,
 };

--- a/frontend/src/components/EventCard/EventCard.styles.ts
+++ b/frontend/src/components/EventCard/EventCard.styles.ts
@@ -26,6 +26,7 @@ export const EventCardStyles = tv({
       fullview: {
         title: 'text-3xl',
         author: 'text-base',
+        description: 'whitespace-pre-line',
       },
     },
   },

--- a/frontend/src/components/EventCard/EventCard.styles.ts
+++ b/frontend/src/components/EventCard/EventCard.styles.ts
@@ -1,3 +1,4 @@
+import { Interactive } from '@components/Card/Card.stories';
 import { tv } from 'tailwind-variants';
 
 export const EventCardStyles = tv({
@@ -13,6 +14,7 @@ export const EventCardStyles = tv({
     description: 'text-base text-ec-secondary',
     attendees: 'text-sm text-ec-secondary',
     buttonText: 'uppercase',
+    interactive: '',
     detailsContainer:
       'text-sm flex gap-2 items-center text-ec-tertiary  hover:text-ec-title transition-colors duration-200',
   },
@@ -22,11 +24,13 @@ export const EventCardStyles = tv({
         title: 'text-xl',
         author: 'text-sm',
         description: 'line-clamp-2',
+        interactive: 'true',
       },
       fullview: {
         title: 'text-3xl',
         author: 'text-base',
         description: 'whitespace-pre-line',
+        interactive: 'false',
       },
     },
   },

--- a/frontend/src/components/EventCard/EventCard.styles.ts
+++ b/frontend/src/components/EventCard/EventCard.styles.ts
@@ -8,12 +8,25 @@ export const EventCardStyles = tv({
     skeletonContainer: 'flex flex-col gap-2',
     bottomContainer: 'flex justify-between',
     date: 'text-sm text-input-primary',
-    title: 'text-xl',
-    author: 'text-sm text-ec-tertiary',
+    title: ' text-ec-title',
+    author: ' text-ec-tertiary',
     description: 'text-base text-ec-secondary',
     attendees: 'text-sm text-ec-secondary',
     buttonText: 'uppercase',
     detailsContainer:
-      'text-sm flex gap-2 items-center text-ec-tertiary  hover:text-text-primary transition-colors duration-200',
+      'text-sm flex gap-2 items-center text-ec-tertiary  hover:text-ec-title transition-colors duration-200',
+  },
+  variants: {
+    variant: {
+      preview: {
+        title: 'text-xl',
+        author: 'text-sm',
+        description: 'line-clamp-2',
+      },
+      fullview: {
+        title: 'text-3xl',
+        author: 'text-base',
+      },
+    },
   },
 });

--- a/frontend/src/components/EventCard/EventCard.tsx
+++ b/frontend/src/components/EventCard/EventCard.tsx
@@ -32,9 +32,11 @@ export default function EventCard(props: EventCardProps) {
     attendees,
     buttonText,
     detailsContainer,
+    interactive,
   } = EventCardStyles({ variant });
 
   const timeStamp = formatTimestamp(props.date);
+  const isInteractive = interactive() === 'true' ? true : false;
 
   /* Determine button variant and state based on action prop */
   const buttonVariant = variantMap[props.action];
@@ -48,7 +50,7 @@ export default function EventCard(props: EventCardProps) {
   );
 
   return (
-    <Card interactive>
+    <Card interactive={isInteractive}>
       <div className={wrapper()}>
         {/* Date Block */}
         <div className={dateContainer()}>

--- a/frontend/src/components/EventCard/EventCard.tsx
+++ b/frontend/src/components/EventCard/EventCard.tsx
@@ -32,13 +32,14 @@ export default function EventCard(props: EventCardProps) {
     attendees,
     buttonText,
     detailsContainer,
-  } = EventCardStyles();
+  } = EventCardStyles({ variant });
 
+  const timeStamp = formatTimestamp(props.date);
+
+  /* Determine button variant and state based on action prop */
   const buttonVariant = variantMap[props.action];
   const buttonState =
     props.action === 'archived' ? 'disabled' : props.isActionPending ? 'loading' : 'default';
-
-  const timeStamp = formatTimestamp(props.date);
 
   const actionButton = (
     <Button variant={buttonVariant} state={buttonState} size="small" onClick={props.onActionClick}>

--- a/frontend/src/components/EventCard/EventCard.tsx
+++ b/frontend/src/components/EventCard/EventCard.tsx
@@ -14,8 +14,10 @@ const variantMap = {
 } as const;
 
 export default function EventCard(props: EventCardProps) {
-  if (props.isLoading) {
-    return <EventCardSkeleton />;
+  const { variant = 'preview', isLoading } = props;
+
+  if (isLoading) {
+    return <EventCardSkeleton variant={variant} />;
   }
 
   const {
@@ -38,15 +40,24 @@ export default function EventCard(props: EventCardProps) {
 
   const timeStamp = formatTimestamp(props.date);
 
+  const actionButton = (
+    <Button variant={buttonVariant} state={buttonState} size="small" onClick={props.onActionClick}>
+      <span className={buttonText()}>{props.action}</span>
+    </Button>
+  );
+
   return (
     <Card interactive>
       <div className={wrapper()}>
+        {/* Date Block */}
         <div className={dateContainer()}>
           <CalendarDotsIcon size={22} aria-hidden="true" />
           <p className={date()} aria-label={`Event date: ${timeStamp}`}>
             {timeStamp}
           </p>
         </div>
+
+        {/* Event Details Block - title, author, description */}
         <div className={wrapper()}>
           <div>
             <p className={title()}>{props.title}</p>
@@ -54,6 +65,8 @@ export default function EventCard(props: EventCardProps) {
           </div>
           <p className={description()}>{props.description}</p>
         </div>
+
+        {/* Attendees Block with action button in fullview mode */}
         <div className={bottomContainer()}>
           <div className={container()}>
             <UsersIcon size={20} aria-hidden="true" />
@@ -64,26 +77,22 @@ export default function EventCard(props: EventCardProps) {
               {props.attendeeCount} of {props.maxAttendees}
             </p>
           </div>
+          {variant === 'fullview' && actionButton}
         </div>
 
-        <div className={bottomContainer()}>
-          <div className={container()}>
-            <Link href={`/events/${props.id}`} className={detailsContainer()}>
-              <ArrowSquareUpRightIcon size={22} aria-hidden="true" />
-              <span>View details</span>
-            </Link>
+        {/* View Details block - only shown in preview mode */}
+        {variant === 'preview' && (
+          <div className={bottomContainer()}>
+            <div className={container()}>
+              <Link href={`/events/${props.id}`} className={detailsContainer()}>
+                <ArrowSquareUpRightIcon size={22} aria-hidden="true" />
+                <span>View details</span>
+              </Link>
+            </div>
+
+            {actionButton}
           </div>
-
-                <Button
-            variant={buttonVariant}
-            state={buttonState}
-            size="small"
-            onClick={props.onActionClick}
-          >
-
-            <span className={buttonText()}>{props.action}</span>
-          </Button>
-        </div>
+        )}
       </div>
     </Card>
   );

--- a/frontend/src/components/EventCard/EventCard.types.ts
+++ b/frontend/src/components/EventCard/EventCard.types.ts
@@ -2,6 +2,13 @@ type EventCardAction = 'join' | 'leave' | 'edit' | 'archived';
 
 type EventCardBaseProps = {
   /**
+   * Display mode for the card.
+   * - `preview` — shows a "View details" link to the event page (default)
+   * - `fullview` — hides the link; intended for use on the event detail page itself
+   * @default 'preview'
+   */
+  variant?: 'preview' | 'fullview';
+  /**
    * The action button text and behavior.
    * - `join` — Shows "JOIN" button with positive variant
    * - `leave` — Shows "LEAVE" button with negative variant

--- a/frontend/src/components/EventCard/EventCardSkeleton.tsx
+++ b/frontend/src/components/EventCard/EventCardSkeleton.tsx
@@ -21,6 +21,12 @@ export default function EventCardSkeleton({ variant }: Pick<EventCardProps, 'var
           <div className="flex flex-col gap-2.5">
             <Skeleton height={16} width="100%" />
             <Skeleton height={16} width="75%" />
+            {variant === 'fullview' && (
+              <>
+                <Skeleton height={16} width="90%" />
+                <Skeleton height={16} width="60%" />
+              </>
+            )}
           </div>
         </div>
         <div className={bottomContainer()}>

--- a/frontend/src/components/EventCard/EventCardSkeleton.tsx
+++ b/frontend/src/components/EventCard/EventCardSkeleton.tsx
@@ -1,8 +1,9 @@
 import { Card } from '../Card';
 import { Skeleton } from '../Skeleton';
 import { EventCardStyles } from './EventCard.styles';
+import type { EventCardProps } from './EventCard.types';
 
-export default function EventCardSkeleton() {
+export default function EventCardSkeleton({ variant }: Pick<EventCardProps, 'variant'>) {
   const { wrapper, container, bottomContainer, skeletonContainer } = EventCardStyles();
 
   return (
@@ -27,14 +28,18 @@ export default function EventCardSkeleton() {
             <Skeleton height={16} width={16} />
             <Skeleton height={16} width={60} />
           </div>
+          {variant === 'fullview' && <Skeleton height={32} width={100} />}
         </div>
-        <div className={bottomContainer()}>
-          <div className={container()}>
-            <Skeleton height={16} width={16} />
-            <Skeleton height={16} width={80} />
+
+        {variant === 'preview' && (
+          <div className={bottomContainer()}>
+            <div className={container()}>
+              <Skeleton height={16} width={16} />
+              <Skeleton height={16} width={80} />
+            </div>
+            <Skeleton height={32} width={100} />
           </div>
-          <Skeleton height={32} width={100} />
-        </div>
+        )}
       </div>
     </Card>
   );

--- a/frontend/src/components/EventCard/EventCardSkeleton.tsx
+++ b/frontend/src/components/EventCard/EventCardSkeleton.tsx
@@ -15,8 +15,11 @@ export default function EventCardSkeleton({ variant }: Pick<EventCardProps, 'var
         </div>
         <div className={wrapper()}>
           <div className={skeletonContainer()}>
-            <Skeleton height={26} width={193} />
-            <Skeleton height={22} width={124} />
+            <Skeleton
+              height={variant === 'preview' ? 26 : 36}
+              width={variant === 'preview' ? 193 : 223}
+            />
+            <Skeleton height={variant === 'preview' ? 16 : 24} width={124} />
           </div>
           <div className="flex flex-col gap-2.5">
             <Skeleton height={16} width="100%" />


### PR DESCRIPTION
added EventCard variations: `preview` (for dashboard & similar pages) and `fullview` for event page. 

Preview: shows max 2 lines of description with no line breaks and contains "View details "link (to the event page). 

Fullview: shows full description with line breaks, does not contain view details link, and is styled with bigger fonts for title and author. (As per Figma spec!). 

Event Skeleton is updated respectively. 

Preview: 
<img width="613" height="343" alt="image" src="https://github.com/user-attachments/assets/e6e0d93d-d9ca-4233-b58a-9d5ebb8fbcad" />


Fullveiw: 
<img width="620" height="401" alt="image" src="https://github.com/user-attachments/assets/8cbbfb01-082d-4397-ba8a-d6f3d25dd046" />


