### PR TITLE
fix: middleware

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,7 @@
 NEXT_PUBLIC_API_URL=http://localhost:4000
 JWT_SECRET=8f3k2j4h9skd92jd8s2k1ls9a
+
+# Preview-only — set on the FRONTEND Vercel project (server env, not NEXT_PUBLIC)
+# API_PROJECT_ID = backend project ID from Vercel → Settings → General (prj_...)
+# VERCEL_TOKEN   = token with read access to deployments (Account → Tokens)
+# VERCEL_GIT_COMMIT_SHA / VERCEL_GIT_COMMIT_REF / VERCEL_TEAM_ID are set automatically by Vercel

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,19 @@
 import type { NextConfig } from 'next';
+import { resolveApiUrl } from './src/config/resolveApiUrl';
+
+const environment = process.env.VERCEL_ENV || 'development';
+const previewApiUrl =
+  environment === 'preview' ? await resolveApiUrl('preview') : process.env.NEXT_PUBLIC_API_URL;
 
 const nextConfig: NextConfig = {
   turbopack: {
     root: './',
+  },
+  env: {
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV,
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA,
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF,
+    ...(previewApiUrl ? { NEXT_PUBLIC_API_URL: previewApiUrl } : {}),
   },
 };
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,9 +1,4 @@
 import type { NextConfig } from 'next';
-import { resolveApiUrl } from './src/config/resolveApiUrl';
-
-const environment = process.env.VERCEL_ENV || 'development';
-const previewApiUrl =
-  environment === 'preview' ? await resolveApiUrl('preview') : process.env.NEXT_PUBLIC_API_URL;
 
 const nextConfig: NextConfig = {
   turbopack: {
@@ -13,7 +8,6 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV,
     NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA,
     NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF,
-    ...(previewApiUrl ? { NEXT_PUBLIC_API_URL: previewApiUrl } : {}),
   },
 };
 

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import {
+  AUTH_COOKIE_NAME,
+  authCookieOptions,
+  extractTokenFromSetCookieHeaders,
+} from '@/lib/authCookie';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const apiUrl = await getBackendApiUrl();
+
+  const backendRes = await fetch(`${apiUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const json = await backendRes.json();
+
+  if (!backendRes.ok) {
+    return NextResponse.json(json, { status: backendRes.status });
+  }
+
+  const token = extractTokenFromSetCookieHeaders(backendRes.headers);
+  if (token) {
+    (await cookies()).set(AUTH_COOKIE_NAME, token, authCookieOptions);
+  }
+
+  return NextResponse.json(json);
+}

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import { AUTH_COOKIE_NAME } from '@/lib/authCookie';
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+
+  cookieStore.delete(AUTH_COOKIE_NAME);
+
+  if (token) {
+    const apiUrl = await getBackendApiUrl();
+    await fetch(`${apiUrl}/auth/logout`, {
+      method: 'POST',
+      headers: { Cookie: `${AUTH_COOKIE_NAME}=${token}` },
+    }).catch(() => undefined);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import { AUTH_COOKIE_NAME } from '@/lib/authCookie';
+
+export async function GET() {
+  const token = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiUrl = await getBackendApiUrl();
+  const backendRes = await fetch(`${apiUrl}/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+
+  const json = await backendRes.json();
+  return NextResponse.json(json, { status: backendRes.status });
+}

--- a/frontend/src/app/api/config/route.ts
+++ b/frontend/src/app/api/config/route.ts
@@ -1,0 +1,10 @@
+import { resolveApiUrl } from '@/config/resolveApiUrl';
+import { getEnvironment } from '@/config/environment';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const environment = getEnvironment();
+  const apiUrl = await resolveApiUrl(environment);
+
+  return NextResponse.json({ environment, apiUrl });
+}

--- a/frontend/src/config/environment.ts
+++ b/frontend/src/config/environment.ts
@@ -1,0 +1,3 @@
+export function getEnvironment(): string {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.VERCEL_ENV || 'development';
+}

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -1,45 +1,59 @@
-const ENVIRONMENT = process.env.NEXT_PUBLIC_VERCEL_ENV || 'development';
-const API_PROJECT_ID = process.env.NEXT_PUBLIC_API_PROJECT_ID;
-const COMMIT_SHA = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
-const VERCEL_TOKEN = process.env.NEXT_PUBLIC_VERCEL_TOKEN;
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-
-// Build API URL dynamically based on Vercel environment
-// If the environment is preview (PR scoped), we need to get the API URL from the Vercel API otherwise use the local .env file
-const getApiUrl = async (): Promise<string> => {
-  if (ENVIRONMENT === 'preview') {
-    try {
-      const response = await fetch(
-        `https://api.vercel.com/v6/deployments?projectId=${API_PROJECT_ID}&target=preview&sha=${COMMIT_SHA}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${VERCEL_TOKEN}`,
-          },
-        }
-      );
-
-      const data = await response.json();
-
-      return `https://${data.deployments[0].url}`;
-    } catch (error) {
-      console.error(error);
-
-      return API_URL;
-    }
-  }
-
-  return API_URL;
-};
+import { DEFAULT_API_URL, isLocalFallbackApiUrl, resolveApiUrl } from './resolveApiUrl';
+import { getEnvironment } from './environment';
 
 export interface ConfigData {
   environment: string;
   apiUrl: string;
 }
 
-export const config = async (): Promise<ConfigData> => {
+let clientConfigPromise: Promise<ConfigData> | null = null;
+
+async function loadClientConfig(): Promise<ConfigData> {
+  try {
+    const response = await fetch('/api/config', { cache: 'no-store' });
+
+    if (!response.ok) {
+      throw new Error(`Config request failed with status ${response.status}`);
+    }
+
+    return (await response.json()) as ConfigData;
+  } catch (error) {
+    console.error('Failed to load client config, using fallback API URL:', error);
+
+    return {
+      environment: getEnvironment(),
+      apiUrl: DEFAULT_API_URL,
+    };
+  }
+}
+
+async function resolveRuntimeConfig(environment: string): Promise<ConfigData> {
+  const bakedApiUrl = process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
+
+  if (environment !== 'preview' || !isLocalFallbackApiUrl(bakedApiUrl)) {
+    return { environment, apiUrl: bakedApiUrl };
+  }
+
   return {
-    environment: ENVIRONMENT,
-    apiUrl: await getApiUrl(),
+    environment,
+    apiUrl: await resolveApiUrl(environment),
   };
+}
+
+export const config = async (): Promise<ConfigData> => {
+  const environment = getEnvironment();
+
+  if (typeof window === 'undefined') {
+    return resolveRuntimeConfig(environment);
+  }
+
+  const bakedApiUrl = process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
+
+  if (environment !== 'preview' || !isLocalFallbackApiUrl(bakedApiUrl)) {
+    return { environment, apiUrl: bakedApiUrl };
+  }
+
+  clientConfigPromise ??= loadClientConfig();
+
+  return clientConfigPromise;
 };

--- a/frontend/src/config/resolveApiUrl.ts
+++ b/frontend/src/config/resolveApiUrl.ts
@@ -1,0 +1,100 @@
+export const DEFAULT_API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type DeploymentsResponse = {
+  deployments?: Array<{ url?: string | null }>;
+};
+
+function getPreviewConfig() {
+  return {
+    projectId: process.env.API_PROJECT_ID ?? process.env.NEXT_PUBLIC_API_PROJECT_ID,
+    commitSha:
+      process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+    branch: process.env.VERCEL_GIT_COMMIT_REF ?? process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF,
+    token: process.env.VERCEL_TOKEN,
+    teamId: process.env.VERCEL_TEAM_ID ?? process.env.VERCEL_ORG_ID,
+  };
+}
+
+async function fetchBackendPreviewUrl(
+  projectId: string,
+  token: string,
+  teamId: string | undefined,
+  filters: Record<string, string>
+): Promise<string | null> {
+  const params = new URLSearchParams({
+    projectId,
+    target: 'preview',
+    state: 'READY',
+    limit: '5',
+    ...filters,
+  });
+
+  if (teamId) {
+    params.set('teamId', teamId);
+  }
+
+  const response = await fetch(`https://api.vercel.com/v6/deployments?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error('Vercel deployments API failed:', response.status, body);
+    return null;
+  }
+
+  const data = (await response.json()) as DeploymentsResponse;
+  const deploymentUrl = data.deployments?.find((deployment) => deployment.url)?.url;
+
+  return deploymentUrl ? `https://${deploymentUrl}` : null;
+}
+
+/**
+ * Resolves the matching backend preview deployment URL for this frontend preview.
+ * Frontend and API live on different *.vercel.app URLs, but share the same git
+ * commit (or branch) when deployed from the same PR — that is what we match on.
+ */
+export async function resolveApiUrl(environment: string): Promise<string> {
+  if (environment !== 'preview') {
+    return DEFAULT_API_URL;
+  }
+
+  const { projectId, commitSha, branch, token, teamId } = getPreviewConfig();
+
+  if (!projectId || !token) {
+    console.warn(
+      'Preview API URL resolution skipped. Set API_PROJECT_ID and VERCEL_TOKEN on the frontend Vercel project.'
+    );
+    return DEFAULT_API_URL;
+  }
+
+  try {
+    if (commitSha) {
+      const bySha = await fetchBackendPreviewUrl(projectId, token, teamId, { sha: commitSha });
+      if (bySha) return bySha;
+    }
+
+    if (branch) {
+      const byBranch = await fetchBackendPreviewUrl(projectId, token, teamId, { branch });
+      if (byBranch) return byBranch;
+    }
+
+    console.warn(
+      `No READY backend preview found for project ${projectId}` +
+        (commitSha ? ` at commit ${commitSha}` : '') +
+        (branch ? ` on branch ${branch}` : '') +
+        '.'
+    );
+  } catch (error) {
+    console.error('Failed to resolve preview API URL:', error);
+  }
+
+  return DEFAULT_API_URL;
+}
+
+export function isLocalFallbackApiUrl(apiUrl: string): boolean {
+  return apiUrl.includes('localhost') || apiUrl.includes('127.0.0.1');
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
+import { getProfileRequest } from '@service/authService';
 import type { AuthUser } from '@service/authService';
 
 interface AuthContextValue {
   authUser: AuthUser | null;
+  hydrating: boolean;
   authenticateUser: (user: AuthUser) => void;
   clearAuthUser: () => void;
 }
@@ -13,20 +15,36 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);
+  const [hydrating, setHydrating] = useState(true);
 
-  const authenticateUser = (user: AuthUser) => {
+  const authenticateUser = useCallback((user: AuthUser) => {
     setAuthUser(user);
-  };
+  }, []);
 
-  const clearAuthUser = () => {
+  const clearAuthUser = useCallback(() => {
     setAuthUser(null);
-  };
+  }, []);
 
-  return (
-    <AuthContext.Provider value={{ authUser, authenticateUser, clearAuthUser }}>
-      {children}
-    </AuthContext.Provider>
+  useEffect(() => {
+    const hydrate = async () => {
+      try {
+        const user = await getProfileRequest();
+        if (user) setAuthUser(user);
+      } catch {
+        // Not authenticated, user stays null
+      } finally {
+        setHydrating(false);
+      }
+    };
+    hydrate();
+  }, []);
+
+  const value = useMemo(
+    () => ({ authUser, hydrating, authenticateUser, clearAuthUser }),
+    [authUser, hydrating, authenticateUser, clearAuthUser],
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuthContext = (): AuthContextValue => {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -24,26 +24,26 @@ export default function useAuth() {
       }
     };
     hydrate();
-  }, []);
+  }, [authenticateUser]);
 
-  const signIn =  async (data: LoginInput) => {
-      try {
-        setLoading(true);
-        setError(undefined);
-        const user = await loginRequest(data);
-        authenticateUser(user);
-        return true;
-      } catch (err: unknown) {
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('An unknown error occurred');
-        }
-        return false;
-      } finally {
-        setLoading(false);
+  const signIn = async (data: LoginInput) => {
+    try {
+      setLoading(true);
+      setError(undefined);
+      const user = await loginRequest(data);
+      authenticateUser(user);
+      return true;
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('An unknown error occurred');
       }
-    };
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const signOut = async () => {
     try {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,30 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useAuthContext } from '@/contexts/AuthContext';
-import { loginRequest, getProfileRequest, logoutRequest } from '@service/authService';
+import { loginRequest, logoutRequest } from '@service/authService';
 import type { LoginInput } from '@validators/schemas';
 import { useRouter } from 'next/navigation';
 
 export default function useAuth() {
-  const { authUser, authenticateUser, clearAuthUser } = useAuthContext();
+  const { authUser, hydrating, authenticateUser, clearAuthUser } = useAuthContext();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  const [hydrating, setHydrating] = useState(true);
   const router = useRouter();
-
-  // Hydrate user from cookie on mount
-  useEffect(() => {
-    const hydrate = async () => {
-      try {
-        const user = await getProfileRequest();
-        if (user) authenticateUser(user);
-      } catch {
-        // Not authenticated, user stays null
-      } finally {
-        setHydrating(false);
-      }
-    };
-    hydrate();
-  }, [authenticateUser]);
 
   const signIn = async (data: LoginInput) => {
     try {

--- a/frontend/src/lib/authCookie.ts
+++ b/frontend/src/lib/authCookie.ts
@@ -1,0 +1,31 @@
+import type { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+
+export const AUTH_COOKIE_NAME = 'token';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const authCookieOptions: Partial<ResponseCookie> = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: 'lax',
+  path: '/',
+  maxAge: 60 * 10,
+};
+
+export function extractTokenFromSetCookieHeaders(headers: Headers): string | null {
+  const rawSetCookie = headers.get('set-cookie');
+  const setCookies =
+    typeof headers.getSetCookie === 'function'
+      ? headers.getSetCookie()
+      : rawSetCookie
+        ? [rawSetCookie]
+        : [];
+
+  for (const header of setCookies) {
+    if (header.startsWith(`${AUTH_COOKIE_NAME}=`)) {
+      return header.split(';')[0].slice(`${AUTH_COOKIE_NAME}=`.length);
+    }
+  }
+
+  return null;
+}

--- a/frontend/src/lib/getBackendApiUrl.ts
+++ b/frontend/src/lib/getBackendApiUrl.ts
@@ -1,0 +1,6 @@
+import { getEnvironment } from '@/config/environment';
+import { resolveApiUrl } from '@/config/resolveApiUrl';
+
+export async function getBackendApiUrl(): Promise<string> {
+  return resolveApiUrl(getEnvironment());
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -29,6 +29,8 @@ export async function middleware(request: NextRequest) {
   const isPublicAuthPath = PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
   const authenticated = token ? await isValidToken(token) : false;
 
+  console.log({ isPublicAuthPath, authenticated, pathname });
+
   if (!isPublicAuthPath && !authenticated) {
     return NextResponse.redirect(new URL('/sign-in', request.url));
   }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -21,6 +21,8 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('token')?.value;
 
+  console.log({ pathname, token });
+
   // bypass auth entirely — accessible to both authenticated and unauthenticated users
   if (ALWAYS_PUBLIC_PATHS.some((path) => pathname.startsWith(path))) {
     return NextResponse.next();

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -21,8 +21,6 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get('token')?.value;
 
-  console.log({ pathname, token });
-
   // bypass auth entirely — accessible to both authenticated and unauthenticated users
   if (ALWAYS_PUBLIC_PATHS.some((path) => pathname.startsWith(path))) {
     return NextResponse.next();
@@ -30,8 +28,6 @@ export async function middleware(request: NextRequest) {
 
   const isPublicAuthPath = PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
   const authenticated = token ? await isValidToken(token) : false;
-
-  console.log({ isPublicAuthPath, authenticated, pathname });
 
   if (!isPublicAuthPath && !authenticated) {
     return NextResponse.redirect(new URL('/sign-in', request.url));

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -26,14 +26,10 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const isAuthPath = PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
+  const isPublicAuthPath = PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
   const authenticated = token ? await isValidToken(token) : false;
 
-  if (authenticated && isAuthPath) {
-    return NextResponse.redirect(new URL('/events', request.url));
-  }
-
-  if (!authenticated && !isAuthPath) {
+  if (!isPublicAuthPath && !authenticated) {
     return NextResponse.redirect(new URL('/sign-in', request.url));
   }
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -31,6 +31,8 @@ export async function middleware(request: NextRequest) {
 
   if (!isPublicAuthPath && !authenticated) {
     return NextResponse.redirect(new URL('/sign-in', request.url));
+  } else if (authenticated && isPublicAuthPath) {
+    return NextResponse.redirect(new URL('/events', request.url));
   }
 
   return NextResponse.next();

--- a/frontend/src/service/authService.ts
+++ b/frontend/src/service/authService.ts
@@ -10,8 +10,7 @@ export interface AuthUser {
 }
 
 export async function loginRequest(data: LoginInput): Promise<AuthUser> {
-  const { apiUrl } = await config();
-  const res = await fetch(`${apiUrl}/auth/login`, {
+  const res = await fetch('/api/auth/login', {
     method: 'POST',
     credentials: 'include',
     headers: {
@@ -30,16 +29,14 @@ export async function loginRequest(data: LoginInput): Promise<AuthUser> {
 }
 
 export async function getProfileRequest(): Promise<AuthUser | null> {
-  const { apiUrl } = await config();
-  const res = await fetch(`${apiUrl}/auth/me`, { credentials: 'include' });
+  const res = await fetch('/api/auth/me', { credentials: 'include' });
   const json = await res.json();
   if (!res.ok) return null;
   return json.user;
 }
 
 export async function logoutRequest(): Promise<void> {
-  const { apiUrl } = await config();
-  const res = await fetch(`${apiUrl}/auth/logout`, {
+  const res = await fetch('/api/auth/logout', {
     credentials: 'include',
     method: 'POST',
   });


### PR DESCRIPTION
# Auth Cookies Across Frontend & Backend: Problem & Fix

## Context

Our app is split into two deployments:

| App | Example URL | Role |
|-----|-------------|------|
| **Frontend** | `https://redi-events-frontend-xxx.vercel.app` | Next.js UI, middleware, server components |
| **Backend** | `https://redi-events-backend-xxx.vercel.app` | Express API, issues JWT, sets auth cookie |

After login, users could appear logged in on the client, but navigating to `/events` redirected them to `/sign-in`.

---

## Symptoms

- Login succeeds — user data loads via `/auth/me`
- DevTools shows a `token` cookie
- Navigating to `/events` redirects to `/sign-in`
- `middleware.ts` logs `token: undefined`

```ts
// middleware.ts
const token = request.cookies.get('token')?.value; // always undefined on /events
```

---

## The Problem (In Plain Terms)

> **The cookie existed, but not on the request that middleware receives.**

We had **two different auth checks** that didn't share the same cookie:

```
┌─────────────────────────────────────────────────────────────────┐
│  Browser                                                        │
│                                                                 │
│  Login: POST → backend.vercel.app/auth/login                    │
│           ← Set-Cookie: token=... (scoped to BACKEND domain)    │
│                                                                 │
│  /auth/me: fetch → backend.vercel.app  ✅ cookie sent           │
│                                                                 │
│  /events:  GET  → frontend.vercel.app/events                    │
│              ↑ browser does NOT attach backend cookie           │
│              → middleware sees no token → redirect to /sign-in  │
└─────────────────────────────────────────────────────────────────┘
```

### Why DevTools Was Misleading

The `token` cookie **was real**, but it belonged to the **backend** origin:

- **Domain:** `redi-events-backend-xxx.vercel.app` (not the frontend)
- **SameSite:** `None` (required for cross-site API calls)
- **Secure:** `true` (HTTPS only)

DevTools can show that cookie while you're on the frontend page because a background `fetch` to the API uses it. That does **not** mean the cookie is sent when you navigate to a frontend URL.

### Cookies Are Per-Origin

A cookie is sent only when the **request URL matches the cookie's domain**.

| Request target | Backend `token` cookie sent? |
|----------------|------------------------------|
| `backend.vercel.app/auth/me` | ✅ Yes |
| `frontend.vercel.app/events` | ❌ No |

So client-side auth worked, but **Next.js middleware** (which runs on frontend requests) never saw the token.

### Why We Can't Share One Cookie Across Both Vercel Apps

The backend intentionally omits a shared `Domain`:

```ts
// backend/src/controllers/authController.ts
// Domain is intentionally omitted (PSL blocks sharing a parent-domain cookie).
```

`vercel.app` is on the [Public Suffix List](https://publicsuffix.org/), so you **cannot** set `Domain=.vercel.app` and share a cookie between two `*.vercel.app` subdomains. Each deployment gets its own cookie scope.

---

## The Solution: BFF Auth Routes (Backend-for-Frontend)

Instead of the browser talking to the backend directly for auth, we added **same-origin API routes** on the frontend that:

1. Proxy auth requests to the backend
2. Read the token from the backend response
3. Set a **new** `token` cookie on the **frontend** domain

```
┌─────────────────────────────────────────────────────────────────┐
│  Browser                                                        │
│                                                                 │
│  Login: POST → frontend.vercel.app/api/auth/login  (same origin)│
│           → Next.js calls backend /auth/login (server-side)     │
│           ← Next.js sets Set-Cookie: token=... on FRONTEND      │
│                                                                 │
│  /events: GET → frontend.vercel.app/events                      │
│           ↑ frontend cookie attached                            │
│           → middleware reads token ✅                           │
└─────────────────────────────────────────────────────────────────┘
```

This pattern is called a **BFF (Backend-for-Frontend)** — a thin server layer on the frontend that adapts the API for browser needs.

---

## What We Changed

### New Files

| File | Purpose |
|------|---------|
| `src/app/api/auth/login/route.ts` | Proxy login → set frontend cookie |
| `src/app/api/auth/me/route.ts` | Read frontend cookie → forward to backend |
| `src/app/api/auth/logout/route.ts` | Clear frontend cookie + backend session |
| `src/lib/authCookie.ts` | Shared cookie name, options, parsing helpers |
| `src/lib/getBackendApiUrl.ts` | Resolve backend URL on the server |

### Login Flow (New)

```ts
// POST /api/auth/login
const backendRes = await fetch(`${apiUrl}/auth/login`, { ... });

// Token comes back in the backend Set-Cookie header (server-to-server)
const token = extractTokenFromSetCookieHeaders(backendRes.headers);

// Set a same-origin cookie the browser will send to Next.js
(await cookies()).set('token', token, {
  httpOnly: true,
  secure: true,       // production
  sameSite: 'lax',    // same-origin → Lax is enough (and safer)
  path: '/',
  maxAge: 60 * 10,    // 10 minutes
});
```

### Updated Client Auth Calls

`authService.ts` now uses same-origin routes:

```ts
// Before
fetch(`${apiUrl}/auth/login`, { credentials: 'include' })

// After
fetch('/api/auth/login', { credentials: 'include' })
```

Same for `/api/auth/me` and `/api/auth/logout`.

### Middleware (Unchanged Logic, Now Works)

```ts
const token = request.cookies.get('token')?.value;
const authenticated = token ? await isValidToken(token) : false;
```

Once the cookie lives on the frontend domain, middleware receives it on every page navigation.

---

## Before vs After

| | Before | After |
|---|--------|-------|
| Login target | Backend directly | `/api/auth/login` (frontend) |
| Cookie domain | Backend `*.vercel.app` | Frontend `*.vercel.app` |
| Client `/me` | Works (cross-origin fetch) | Works (same-origin BFF) |
| Middleware | `token` undefined | `token` present |
| `/events` access | Redirect to sign-in | Allowed when logged in |
| Server components (`cookies()`) | No token | Token available |

---

## How to Verify It Works

1. **Sign out**, then **sign in again** (old backend-only cookies are not migrated).
2. Open DevTools → **Application → Cookies** → select your **frontend** URL.
3. Confirm `token` exists with:
   - **Domain** = frontend hostname (e.g. `redi-events-frontend-xxx.vercel.app`)
   - **SameSite** = `Lax`
4. Open **Network** → navigate to `/events` → check the **document** request → `Cookie: token=...` in request headers.
5. Confirm middleware allows access and `/events` loads.

---

## Deployment Checklist

On the **frontend** Vercel project, ensure:

- [ ] `JWT_SECRET` is set (same value as backend) — middleware verifies the JWT locally
- [ ] `NEXT_PUBLIC_API_URL` points to the backend (production/preview)

After deploy, users must **log in again** once so the frontend cookie is set.

---

## Key Takeaways

1. **"Logged in" in React ≠ "authenticated" in middleware** — they read cookies from different requests/origins.
2. **DevTools showing a cookie ≠ cookie sent on every request** — check the **Domain** column and the **Network** tab `Cookie` header for the specific request.
3. **Cross-origin auth cookies don't work with Next.js middleware** when frontend and API are on different domains.
4. **BFF routes** are a standard fix: proxy auth on the frontend origin so cookies, middleware, and server components all see the same session.

---

## Further Reading

- [MDN: How cookies work](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
- [MDN: SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)
- [Public Suffix List](https://publicsuffix.org/) — why `Domain=.vercel.app` is not allowed
- [Next.js Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
