### PR TITLE
Fix create event sumbit and links

### DIFF
--- a/frontend/src/app/(private)/events/[id]/page.tsx
+++ b/frontend/src/app/(private)/events/[id]/page.tsx
@@ -25,6 +25,10 @@ export default function EventPage() {
     }
   }, [error, loading, router]);
 
+  const handleCreateEventRedirect = () => {
+    router.push('/create-event');
+  };
+
   if (loading)
     return (
       <div className="w-full">
@@ -46,17 +50,14 @@ export default function EventPage() {
           GO BACK
         </LinkButton>
         <Button
-          onClick={() => router.push('/event-creation-page')}
+          onClick={handleCreateEventRedirect}
           size="default"
           variant="idle"
           className="hidden sm:block"
         >
           CREATE NEW EVENT
         </Button>
-        <StickyButton
-          onClick={() => router.push('/event-creation-page')}
-          label="CREATE NEW EVENT"
-        ></StickyButton>
+        <StickyButton onClick={handleCreateEventRedirect} label="CREATE NEW EVENT"></StickyButton>
       </div>
       <div className="w-full flex flex-col gap-5 lg:flex-row">
         {error?.includes('404') || !event ? (

--- a/frontend/src/app/api/events/[id]/attend/route.ts
+++ b/frontend/src/app/api/events/[id]/attend/route.ts
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import { AUTH_COOKIE_NAME } from '@/lib/authCookie';
+
+async function proxy(method: string, id: string) {
+  const token = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const apiUrl = await getBackendApiUrl();
+  const backendRes = await fetch(`${apiUrl}/events/${id}/attend`, {
+    method,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (method === 'DELETE' && backendRes.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const json = await backendRes.json();
+  return NextResponse.json(json, { status: backendRes.status });
+}
+
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return proxy('POST', id);
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return proxy('DELETE', id);
+}

--- a/frontend/src/app/api/events/[id]/route.ts
+++ b/frontend/src/app/api/events/[id]/route.ts
@@ -1,0 +1,43 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import { AUTH_COOKIE_NAME } from '@/lib/authCookie';
+
+async function getAuthHeaders() {
+  const token = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
+  if (!token) return null;
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const authHeaders = await getAuthHeaders();
+  if (!authHeaders) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const apiUrl = await getBackendApiUrl();
+  const backendRes = await fetch(`${apiUrl}/events/${id}`, {
+    headers: authHeaders,
+    cache: 'no-store',
+  });
+
+  const json = await backendRes.json();
+  return NextResponse.json(json, { status: backendRes.status });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const authHeaders = await getAuthHeaders();
+  if (!authHeaders) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const apiUrl = await getBackendApiUrl();
+  const body = await req.json();
+
+  const backendRes = await fetch(`${apiUrl}/events/${id}`, {
+    method: 'PUT',
+    headers: { ...authHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const json = await backendRes.json();
+  return NextResponse.json(json, { status: backendRes.status });
+}

--- a/frontend/src/app/api/events/route.ts
+++ b/frontend/src/app/api/events/route.ts
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { getBackendApiUrl } from '@/lib/getBackendApiUrl';
+import { AUTH_COOKIE_NAME } from '@/lib/authCookie';
+
+export async function POST(request: Request) {
+  const token = (await cookies()).get(AUTH_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiUrl = await getBackendApiUrl();
+  const body = await request.json();
+
+  const backendRes = await fetch(`${apiUrl}/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const json = await backendRes.json();
+  return NextResponse.json(json, { status: backendRes.status });
+}

--- a/frontend/src/hooks/useCreateEvent.ts
+++ b/frontend/src/hooks/useCreateEvent.ts
@@ -19,11 +19,8 @@ export default function useCreateEvent() {
         ...formData,
         location: 'Online',
       };
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-
-      const response = await fetch(`${baseUrl}/events`, {
+      const response = await fetch('/api/events', {
         method: 'POST',
-        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -6,10 +6,6 @@ function getHeaders(): HeadersInit {
   };
 }
 
-function getApiUrl(): string {
-  return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-}
-
 export type RawEvent = {
   id: string;
   title: string;
@@ -28,10 +24,9 @@ export type RawEvent = {
 };
 
 export async function fetchEventById(id: string): Promise<RawEvent> {
-  const url = `${getApiUrl()}/events/${id}`;
-  const res = await fetch(url, {
+  const res = await fetch(`/api/events/${id}`, {
     headers: getHeaders(),
-    credentials: 'include',
+    cache: 'no-store',
   });
 
   if (!res.ok) {
@@ -43,11 +38,9 @@ export async function fetchEventById(id: string): Promise<RawEvent> {
 }
 
 export async function joinEvent(eventId: string): Promise<RawEvent> {
-  const url = `${getApiUrl()}/events/${eventId}/attend`;
-  const res = await fetch(url, {
+  const res = await fetch(`/api/events/${eventId}/attend`, {
     method: 'POST',
     headers: getHeaders(),
-    credentials: 'include',
   });
 
   if (!res.ok) {
@@ -59,11 +52,9 @@ export async function joinEvent(eventId: string): Promise<RawEvent> {
 }
 
 export async function leaveEvent(eventId: string): Promise<void> {
-  const url = `${getApiUrl()}/events/${eventId}/attend`;
-  const res = await fetch(url, {
+  const res = await fetch(`/api/events/${eventId}/attend`, {
     method: 'DELETE',
     headers: getHeaders(),
-    credentials: 'include',
   });
 
   if (!res.ok) {
@@ -72,11 +63,9 @@ export async function leaveEvent(eventId: string): Promise<void> {
 }
 
 export async function updateEvent(id: string, updates: Partial<RawEvent>): Promise<RawEvent> {
-  const url = `${getApiUrl()}/events/${id}`;
-  const res = await fetch(url, {
+  const res = await fetch(`/api/events/${id}`, {
     method: 'PUT',
-    headers: { ...getHeaders(), 'Content-Type': 'application/json' },
-    credentials: 'include',
+    headers: getHeaders(),
     body: JSON.stringify(updates),
   });
 


### PR DESCRIPTION
- fix: proxy POST /events through Next.js API route to fix Vercel preview

Direct client fetch used a build-time env var for the backend URL and
relied on cross-domain cookies (SameSite=Lax), both of which break on
Vercel preview deployments. Adds /api/events server route that resolves
the backend URL at request time and forwards the auth token from the
httpOnly cookie as an Authorization header.

- fix: route name for redirect to event creation page from Event page


