### PR TITLE
Fixing go back and logo links for production

### DIFF
--- a/frontend/src/app/(private)/create-event/page.tsx
+++ b/frontend/src/app/(private)/create-event/page.tsx
@@ -10,13 +10,18 @@ export default function EventCreationPage() {
   const { createEvent, isLoading, serverError } = useCreateEvent();
 
   const handleCancel = () => {
-    router.push('/');
+    router.back();
   };
 
   return (
     <>
       <div className="flex items-center justify-start mb-6 lg:mb-12">
-        <LinkButton href="/" icon={<ArrowLeftIcon size={16} />} onClick={handleCancel}>
+        <LinkButton
+          href="/events"
+          icon={<ArrowLeftIcon size={16} />}
+          color="secondary"
+          onClick={handleCancel}
+        >
           GO BACK
         </LinkButton>
       </div>

--- a/frontend/src/app/(private)/events/[id]/page.tsx
+++ b/frontend/src/app/(private)/events/[id]/page.tsx
@@ -29,6 +29,10 @@ export default function EventPage() {
     router.push('/create-event');
   };
 
+  const handleGoBack = () => {
+    router.back();
+  };
+
   if (loading)
     return (
       <div className="w-full">
@@ -46,7 +50,12 @@ export default function EventPage() {
   return (
     <main className="flex flex-col gap-8">
       <div className="flex justify-between">
-        <LinkButton icon={<ArrowLeftIcon />} color="secondary" href="/events">
+        <LinkButton
+          icon={<ArrowLeftIcon />}
+          color="secondary"
+          onClick={handleGoBack}
+          href="/events"
+        >
           GO BACK
         </LinkButton>
         <Button

--- a/frontend/src/components/Logo/Logo.tsx
+++ b/frontend/src/components/Logo/Logo.tsx
@@ -14,7 +14,7 @@ type LogoVariantsDictionary = {
     width: number;
     height: number;
   };
-}
+};
 
 const LOGO_VARIANTS_DICTIONARY: LogoVariantsDictionary = {
   full: {
@@ -37,7 +37,7 @@ const LOGO_VARIANTS_DICTIONARY: LogoVariantsDictionary = {
 
 const Logo = ({ size = 'full', textColor = 'default' }: LogoProps) => {
   return (
-    <Link href="/" aria-label="Go to homepage">
+    <Link href="/events" aria-label="Go to homepage">
       <Image
         src={LOGO_VARIANTS_DICTIONARY[size].textColor[textColor]}
         alt=""


### PR DESCRIPTION
Fixing go back and logo links for production

- Fixing the go back button on the event page
- Fixing the go back button on the event creation page
- Fixing the link on the logo button to /events in stead of /