### PR TITLE
fix: routing and login issues

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -31,7 +31,7 @@ export class AuthController {
 
       res.cookie('token', token, {
         ...authCookieOptions,
-        maxAge: 1000 * 60 * 10,
+        maxAge: 1000 * 60 * 60 * 24,
       });
 
       const userResponse = new UserDTO(user);

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -29,7 +29,7 @@ export class AuthService {
     };
 
     const token = jwt.sign(tokenPayload, process.env.JWT_SECRET, {
-      expiresIn: '10m',
+      expiresIn: '1d',
     });
 
     return { token, user };

--- a/frontend/src/app/(public)/sign-in/page.tsx
+++ b/frontend/src/app/(public)/sign-in/page.tsx
@@ -13,6 +13,7 @@ export default function LoginPage() {
     const loggedIn = await signIn(data);
 
     if (loggedIn) {
+      router.refresh();
       router.push('/events');
     }
   };

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -23,6 +23,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/events', request.url));
   }
 
+  if (pathname === '/') {
+    return NextResponse.redirect(new URL(token ? '/events' : '/sign-in', request.url));
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
Resolves #158 

What changed
- Extended token lifetime from 10min to 1 day (cookie maxAge + JWT expiresIn)
- Added router.refresh() before router.push('/events') to fix post-login redirect in production
- Middleware now redirects / to /events for authenticated users and /sign-in for unauthenticated users

Why
- Users were being logged out after 10 minutes
- In production, router.push alone doesn't wait for the cookie to be visible to the Next.js router; router.refresh() forces it to re-sync before navigating
- Visiting the root URL was landing on a blank page instead of routing the user appropriately